### PR TITLE
Add a config option to disable shift right clicking groundcover

### DIFF
--- a/src/main/java/vibrantjourneys/blocks/BlockGroundCover.java
+++ b/src/main/java/vibrantjourneys/blocks/BlockGroundCover.java
@@ -29,6 +29,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import vibrantjourneys.util.IPropertyHelper;
+import vibrantjourneys.util.PVJConfig;
 
 public class BlockGroundCover extends Block implements IPropertyHelper
 {
@@ -163,7 +164,7 @@ public class BlockGroundCover extends Block implements IPropertyHelper
 		}
 		else
 		{
-			if(player.isSneaking())
+			if(player.isSneaking() && PVJConfig.misc.shiftRightClickGroundCover)
 			{
 				ItemStack stack = new ItemStack(this, 1, 0);
 				InventoryHelper.spawnItemStack(world, pos.getX(), pos.getY(), pos.getZ(), stack);

--- a/src/main/java/vibrantjourneys/util/PVJConfig.java
+++ b/src/main/java/vibrantjourneys/util/PVJConfig.java
@@ -404,6 +404,11 @@ public class PVJConfig
 		public boolean restrictSquidsToOceans = true;
 		
 		@Comment({
+			"If true, you can shift right click on groundcover to drop their item"
+		})
+		public boolean shiftRightClickGroundCover = true;
+		
+		@Comment({
 			"This is measured in ticks. 20 ticks = 1 second",
 			"6000 ticks = 5 minutes"
 		})


### PR DESCRIPTION
I think this will be useful for modpacks, specifically I want to disallow getting the base item in order to use it as more of a "rock resource" block. And other people might just want to disable the behavior for other reasons.