### PR TITLE
Mitigate bug where banshee attacking player leads to uncaught exception

### DIFF
--- a/src/main/java/vibrantjourneys/entities/monster/EntityBanshee.java
+++ b/src/main/java/vibrantjourneys/entities/monster/EntityBanshee.java
@@ -86,8 +86,12 @@ public class EntityBanshee extends EntityMob
 	@Override
     public boolean attackEntityAsMob(Entity entity)
     {
-		((EntityMob)entity).addPotionEffect(new PotionEffect(Potion.getPotionFromResourceLocation("slowness"), 100, 0));
-		return super.attackEntityAsMob(entity);
+        try {
+            ((EntityMob)entity).addPotionEffect(new PotionEffect(Potion.getPotionFromResourceLocation("slowness"), 100, 0));
+            return super.attackEntityAsMob(entity);
+        } catch (Exception e) {
+            return super.attackEntityAsMob(entity);
+        }
     }
 	
 	@Override


### PR DESCRIPTION
Whenever a banshee attacks a player the cast to EntityMob fails. Leading to an unhandled exception, which takes down servers. 

By adding the try catch, this crash is mitigated, but no potion effect will be applied. 