### PR TITLE
Updated loot tables for shearable blocks to allow modded shears to harvest them

### DIFF
--- a/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/aspen_fallen_leaves.json
+++ b/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/aspen_fallen_leaves.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/aspen_leaves.json
+++ b/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/aspen_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/baobab_leaves.json
+++ b/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/baobab_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/beach_grass.json
+++ b/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/beach_grass.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/berried_juniper_leaves.json
+++ b/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/berried_juniper_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {
@@ -154,7 +154,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/cottonwood_leaves.json
+++ b/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/cottonwood_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/dry_grass.json
+++ b/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/dry_grass.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/fallen_leaves.json
+++ b/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/fallen_leaves.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/fir_leaves.json
+++ b/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/fir_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/joshua_leaves.json
+++ b/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/joshua_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/juniper_leaves.json
+++ b/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/juniper_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/mangrove_leaves.json
+++ b/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/mangrove_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/natural_cobweb.json
+++ b/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/natural_cobweb.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {

--- a/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/orange_maple_fallen_leaves.json
+++ b/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/orange_maple_fallen_leaves.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/orange_maple_leaves.json
+++ b/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/orange_maple_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/palm_leaves.json
+++ b/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/palm_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/pine_leaves.json
+++ b/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/pine_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/pink_sakura_fallen_leaves.json
+++ b/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/pink_sakura_fallen_leaves.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/pink_sakura_leaves.json
+++ b/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/pink_sakura_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/prairie_grass.json
+++ b/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/prairie_grass.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/purple_maple_fallen_leaves.json
+++ b/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/purple_maple_fallen_leaves.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/purple_maple_leaves.json
+++ b/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/purple_maple_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/red_maple_fallen_leaves.json
+++ b/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/red_maple_fallen_leaves.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/red_maple_leaves.json
+++ b/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/red_maple_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/redwood_leaves.json
+++ b/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/redwood_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/short_grass.json
+++ b/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/short_grass.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/tamarack_leaves.json
+++ b/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/tamarack_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/white_sakura_fallen_leaves.json
+++ b/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/white_sakura_fallen_leaves.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/white_sakura_leaves.json
+++ b/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/white_sakura_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/willow_leaves.json
+++ b/src/main/resources/data/projectvibrantjourneys/loot_tables/blocks/willow_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {


### PR DESCRIPTION
When Shears from other mods, Botania for example, are used on BYG blocks that require shears to harvest, they drop nothing. This PR fixes that by changing the match tool predicate to `"tag": "forge:shears"`, which all modded Shears should be in.