### PR TITLE
Fix texture flickering

### DIFF
--- a/src/main/resources/assets/projectvibrantjourneys/models/block/pinecones0.json
+++ b/src/main/resources/assets/projectvibrantjourneys/models/block/pinecones0.json
@@ -1,229 +1,230 @@
 {
+	"credit": "Made with Blockbench",
 	"parent": "block/thin_block",
-    "textures": {
-    	"particle": "block/oak_log",
-        "0": "block/oak_log"
-    },
-    "elements": [
-        {
-            "name": "Pine1",
-            "from": [ 2.0, 1.0, 3.0 ], 
-            "to": [ 7.0, 2.0, 4.0 ], 
-            "rotation": { "origin": [ 4.5, 1.0, 3.5 ], "axis": "y", "angle": -45.0 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine2",
-            "from": [ 4.0, 1.0, 1.0 ], 
-            "to": [ 5.0, 2.0, 6.0 ], 
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 5.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 5.0 ] }
-            }
-        },
-        {
-            "name": "Pine3",
-            "from": [ 2.0, 1.0, 3.0 ], 
-            "to": [ 7.0, 2.0, 4.0 ], 
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine4",
-            "from": [ 2.0, 1.0, 3.0 ], 
-            "to": [ 7.0, 2.0, 4.0 ], 
-            "rotation": { "origin": [ 4.5, 1.0, 3.5 ], "axis": "y", "angle": 45.0 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine5",
-            "from": [ 4.0, 2.0, 1.5 ], 
-            "to": [ 5.0, 3.0, 5.5 ], 
-            "rotation": { "origin": [ 4.5, 1.0, 3.5 ], "axis": "y", "angle": -22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] }
-            }
-        },
-        {
-            "name": "Pine6",
-            "from": [ 4.0, 2.0, 1.5 ], 
-            "to": [ 5.0, 3.0, 5.5 ], 
-            "rotation": { "origin": [ 4.5, 1.0, 3.5 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] }
-            }
-        },
-        {
-            "name": "Pine7",
-            "from": [ 2.5, 2.0, 3.0 ], 
-            "to": [ 6.5, 3.0, 4.0 ], 
-            "rotation": { "origin": [ 4.5, 1.0, 3.5 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine8",
-            "from": [ 2.5, 2.0, 3.0 ], 
-            "to": [ 6.5, 3.0, 4.0 ], 
-            "rotation": { "origin": [ 4.5, 1.0, 3.5 ], "axis": "y", "angle": -22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine9",
-            "from": [ 3.0, 3.0, 3.0 ], 
-            "to": [ 6.0, 4.0, 4.0 ], 
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine10",
-            "from": [ 4.0, 3.0, 2.0 ], 
-            "to": [ 5.0, 4.0, 5.0 ], 
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 3.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 3.0 ] }
-            }
-        },
-        {
-            "name": "Pine11",
-            "from": [ 4.0, 4.0, 3.0 ], 
-            "to": [ 5.0, 5.0, 4.0 ], 
-            "rotation": { "origin": [ 4.5, 1.0, 3.5 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine12",
-            "from": [ 4.0, 0.0, 1.5 ], 
-            "to": [ 5.0, 1.0, 5.5 ], 
-            "rotation": { "origin": [ 4.5, 1.0, 3.5 ], "axis": "y", "angle": -22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] }
-            }
-        },
-        {
-            "name": "Pine13",
-            "from": [ 4.0, 0.0, 1.5 ], 
-            "to": [ 5.0, 1.0, 5.5 ], 
-            "rotation": { "origin": [ 4.5, 1.0, 3.5 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] }
-            }
-        },
-        {
-            "name": "Pine14",
-            "from": [ 2.5, 0.0, 3.0 ], 
-            "to": [ 6.5, 1.0, 4.0 ], 
-            "rotation": { "origin": [ 4.5, 1.0, 3.5 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine15",
-            "from": [ 2.5, 0.0, 3.0 ], 
-            "to": [ 6.5, 1.0, 4.0 ], 
-            "rotation": { "origin": [ 4.5, 1.0, 3.5 ], "axis": "y", "angle": -22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Cube",
-            "from": [ 8.0, 0.0, 13.0 ], 
-            "to": [ 12.0, 1.0, 14.0 ], 
-            "rotation": { "origin": [ 6.0, 8.0, 7.0 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] }
-            }
-        }
-    ]
+	"textures": {
+		"0": "block/oak_log",
+		"particle": "block/oak_log"
+	},
+	"elements": [
+		{
+			"name": "Pine1",
+			"from": [2, 1, 3],
+			"to": [7, 2, 4],
+			"rotation": {"angle": -45, "axis": "y", "origin": [4.5, 1, 3.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 5, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine2",
+			"from": [4, 1, 1],
+			"to": [5, 2, 6],
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 5], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 5], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine3",
+			"from": [2, 1, 3],
+			"to": [7, 2, 4],
+			"faces": {
+				"north": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 5, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine4",
+			"from": [2, 1, 3],
+			"to": [7, 2, 4],
+			"rotation": {"angle": 45, "axis": "y", "origin": [4.5, 1, 3.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 5, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine5",
+			"from": [4, 2, 1.5],
+			"to": [5, 3.1, 5.5],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [4.5, 1, 3.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 4], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 4], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine6",
+			"from": [4, 2, 1.5],
+			"to": [5, 3, 5.5],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [4.5, 1, 3.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 4], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 4], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine7",
+			"from": [2.5, 2, 3],
+			"to": [6.5, 3, 4],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [4.5, 1, 3.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 4, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine8",
+			"from": [2.5, 2, 3],
+			"to": [6.5, 2.9, 4],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [4.5, 1, 3.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 4, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine9",
+			"from": [3, 3, 3],
+			"to": [6, 4, 4],
+			"faces": {
+				"north": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 3, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine10",
+			"from": [4, 3, 2],
+			"to": [5, 3.9, 5],
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 3], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 3], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine11",
+			"from": [4, 4, 3],
+			"to": [5, 5, 4],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [4.5, 1, 3.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine12",
+			"from": [4, 0, 1.5],
+			"to": [5, 1, 5.5],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [4.5, 1, 3.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 4], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 4], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine13",
+			"from": [4, 0, 1.5],
+			"to": [5, 1, 5.5],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [4.5, 1, 3.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 4], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 4], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine14",
+			"from": [2.5, 0, 3],
+			"to": [6.5, 1, 4],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [4.5, 1, 3.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 4, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine15",
+			"from": [2.5, 0, 3],
+			"to": [6.5, 1, 4],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [4.5, 1, 3.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 4, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Cube",
+			"from": [8, 0, 13],
+			"to": [12, 1, 14],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [6, 8, 7]},
+			"faces": {
+				"north": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 4, 1], "texture": "#0"}
+			}
+		}
+	]
 }

--- a/src/main/resources/assets/projectvibrantjourneys/models/block/pinecones1.json
+++ b/src/main/resources/assets/projectvibrantjourneys/models/block/pinecones1.json
@@ -1,257 +1,258 @@
 {
+	"credit": "Made with Blockbench",
 	"parent": "block/thin_block",
-    "textures": {
-    	"particle": "block/oak_log",
-        "0": "block/oak_log"
-    },
-    "elements": [
-        {
-            "name": "Pine1",
-            "from": [ 4.0, 1.0, 5.0 ], 
-            "to": [ 9.0, 2.0, 6.0 ], 
-            "rotation": { "origin": [ 6.5, 1.0, 5.5 ], "axis": "y", "angle": -45.0 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine2",
-            "from": [ 6.0, 1.0, 3.0 ], 
-            "to": [ 7.0, 2.0, 8.0 ], 
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 5.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 5.0 ] }
-            }
-        },
-        {
-            "name": "Pine3",
-            "from": [ 4.0, 1.0, 5.0 ], 
-            "to": [ 9.0, 2.0, 6.0 ], 
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine4",
-            "from": [ 4.0, 1.0, 5.0 ], 
-            "to": [ 9.0, 2.0, 6.0 ], 
-            "rotation": { "origin": [ 6.5, 1.0, 5.5 ], "axis": "y", "angle": 45.0 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine5",
-            "from": [ 6.0, 2.0, 3.5 ], 
-            "to": [ 7.0, 3.0, 7.5 ], 
-            "rotation": { "origin": [ 6.5, 1.0, 5.5 ], "axis": "y", "angle": -22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] }
-            }
-        },
-        {
-            "name": "Pine6",
-            "from": [ 6.0, 2.0, 3.5 ], 
-            "to": [ 7.0, 3.0, 7.5 ], 
-            "rotation": { "origin": [ 6.5, 1.0, 5.5 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] }
-            }
-        },
-        {
-            "name": "Pine7",
-            "from": [ 4.5, 2.0, 5.0 ], 
-            "to": [ 8.5, 3.0, 6.0 ], 
-            "rotation": { "origin": [ 6.5, 1.0, 5.5 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine8",
-            "from": [ 4.5, 2.0, 5.0 ], 
-            "to": [ 8.5, 3.0, 6.0 ], 
-            "rotation": { "origin": [ 6.5, 1.0, 5.5 ], "axis": "y", "angle": -22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine9",
-            "from": [ 5.0, 3.0, 5.0 ], 
-            "to": [ 8.0, 4.0, 6.0 ], 
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine10",
-            "from": [ 6.0, 3.0, 4.0 ], 
-            "to": [ 7.0, 4.0, 7.0 ], 
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 3.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 3.0 ] }
-            }
-        },
-        {
-            "name": "Pine11",
-            "from": [ 6.0, 4.0, 5.0 ], 
-            "to": [ 7.0, 5.0, 6.0 ], 
-            "rotation": { "origin": [ 6.5, 1.0, 5.5 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine12",
-            "from": [ 6.0, 0.0, 3.5 ], 
-            "to": [ 7.0, 1.0, 7.5 ], 
-            "rotation": { "origin": [ 6.5, 1.0, 5.5 ], "axis": "y", "angle": -22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] }
-            }
-        },
-        {
-            "name": "Pine13",
-            "from": [ 6.0, 0.0, 3.5 ], 
-            "to": [ 7.0, 1.0, 7.5 ], 
-            "rotation": { "origin": [ 6.5, 1.0, 5.5 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] }
-            }
-        },
-        {
-            "name": "Pine14",
-            "from": [ 4.5, 0.0, 5.0 ], 
-            "to": [ 8.5, 1.0, 6.0 ], 
-            "rotation": { "origin": [ 6.5, 1.0, 5.5 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine15",
-            "from": [ 4.5, 0.0, 5.0 ], 
-            "to": [ 8.5, 1.0, 6.0 ], 
-            "rotation": { "origin": [ 6.5, 1.0, 5.5 ], "axis": "y", "angle": -22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Stick1",
-            "from": [ 8.0, 0.0, 13.0 ], 
-            "to": [ 12.0, 1.0, 14.0 ], 
-            "rotation": { "origin": [ 6.0, 8.0, 7.0 ], "axis": "y", "angle": -22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Stick2",
-            "from": [ 1.0, 0.0, 5.0 ], 
-            "to": [ 2.0, 1.0, 10.0 ], 
-            "rotation": { "origin": [ 6.0, 9.0, 7.0 ], "axis": "y", "angle": -45.0 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 5.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 5.0 ] }
-            }
-        },
-        {
-            "name": "Stick3",
-            "from": [ 14.0, 1.0, 10.0 ], 
-            "to": [ 15.0, 2.0, 15.0 ], 
-            "rotation": { "origin": [ 6.0, 9.0, 7.0 ], "axis": "x", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 5.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 5.0 ] }
-            }
-        }
-    ]
+	"textures": {
+		"0": "block/oak_log",
+		"particle": "block/oak_log"
+	},
+	"elements": [
+		{
+			"name": "Pine1",
+			"from": [4, 1, 5],
+			"to": [9, 2, 6],
+			"rotation": {"angle": -45, "axis": "y", "origin": [6.5, 1, 5.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 5, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine2",
+			"from": [6, 1, 3],
+			"to": [7, 2, 8],
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 5], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 5], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine3",
+			"from": [4, 1, 5],
+			"to": [9, 2, 6],
+			"faces": {
+				"north": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 5, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine4",
+			"from": [4, 1, 5],
+			"to": [9, 2, 6],
+			"rotation": {"angle": 45, "axis": "y", "origin": [6.5, 1, 5.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 5, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine5",
+			"from": [6, 2, 3.5],
+			"to": [7, 2.9, 7.5],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [6.5, 1, 5.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 4], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 4], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine6",
+			"from": [6, 2, 3.5],
+			"to": [7, 3, 7.5],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [6.5, 1, 5.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 4], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 4], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine7",
+			"from": [4.5, 2, 5],
+			"to": [8.5, 3, 6],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [6.5, 1, 5.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 4, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine8",
+			"from": [4.5, 2, 5],
+			"to": [8.5, 3.1, 6],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [6.5, 1, 5.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 4, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine9",
+			"from": [5, 3, 5],
+			"to": [8, 4, 6],
+			"faces": {
+				"north": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 3, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine10",
+			"from": [6, 3, 4],
+			"to": [7, 3.9, 7],
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 3], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 3], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine11",
+			"from": [6, 4, 5],
+			"to": [7, 5, 6],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [6.5, 1, 5.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine12",
+			"from": [6, 0, 3.5],
+			"to": [7, 1, 7.5],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [6.5, 1, 5.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 4], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 4], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine13",
+			"from": [6, 0, 3.5],
+			"to": [7, 1, 7.5],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [6.5, 1, 5.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 4], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 4], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine14",
+			"from": [4.5, 0, 5],
+			"to": [8.5, 1, 6],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [6.5, 1, 5.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 4, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine15",
+			"from": [4.5, 0, 5],
+			"to": [8.5, 1, 6],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [6.5, 1, 5.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 4, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Stick1",
+			"from": [8, 0, 13],
+			"to": [12, 1, 14],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [6, 8, 7]},
+			"faces": {
+				"north": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 4, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Stick2",
+			"from": [1, 0, 5],
+			"to": [2, 1, 10],
+			"rotation": {"angle": -45, "axis": "y", "origin": [6, 9, 7]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 5], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 5], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Stick3",
+			"from": [14, 1, 10],
+			"to": [15, 2, 15],
+			"rotation": {"angle": 22.5, "axis": "x", "origin": [6, 9, 7]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 5], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 5], "texture": "#0"}
+			}
+		}
+	]
 }

--- a/src/main/resources/assets/projectvibrantjourneys/models/block/pinecones2.json
+++ b/src/main/resources/assets/projectvibrantjourneys/models/block/pinecones2.json
@@ -1,271 +1,272 @@
 {
+	"credit": "Made with Blockbench",
 	"parent": "block/thin_block",
-    "textures": {
-    	"particle": "block/oak_log",
-        "0": "block/oak_log"
-    },
-    "elements": [
-        {
-            "name": "Pine1",
-            "from": [ 9.0, 1.0, 5.0 ], 
-            "to": [ 14.0, 2.0, 6.0 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 5.5 ], "axis": "y", "angle": -45.0 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine2",
-            "from": [ 11.0, 1.0, 3.0 ], 
-            "to": [ 12.0, 2.0, 8.0 ], 
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 5.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 5.0 ] }
-            }
-        },
-        {
-            "name": "Pine3",
-            "from": [ 9.0, 1.0, 5.0 ], 
-            "to": [ 14.0, 2.0, 6.0 ], 
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine4",
-            "from": [ 9.0, 1.0, 5.0 ], 
-            "to": [ 14.0, 2.0, 6.0 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 5.5 ], "axis": "y", "angle": 45.0 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine5",
-            "from": [ 11.0, 2.0, 3.5 ], 
-            "to": [ 12.0, 3.0, 7.5 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 5.5 ], "axis": "y", "angle": -22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] }
-            }
-        },
-        {
-            "name": "Pine6",
-            "from": [ 11.0, 2.0, 3.5 ], 
-            "to": [ 12.0, 3.0, 7.5 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 5.5 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] }
-            }
-        },
-        {
-            "name": "Pine7",
-            "from": [ 9.5, 2.0, 5.0 ], 
-            "to": [ 13.5, 3.0, 6.0 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 5.5 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine8",
-            "from": [ 9.5, 2.0, 5.0 ], 
-            "to": [ 13.5, 3.0, 6.0 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 5.5 ], "axis": "y", "angle": -22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine9",
-            "from": [ 10.0, 3.0, 5.0 ], 
-            "to": [ 13.0, 4.0, 6.0 ], 
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine10",
-            "from": [ 11.0, 3.0, 4.0 ], 
-            "to": [ 12.0, 4.0, 7.0 ], 
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 3.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 3.0 ] }
-            }
-        },
-        {
-            "name": "Pine11",
-            "from": [ 11.0, 4.0, 5.0 ], 
-            "to": [ 12.0, 5.0, 6.0 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 5.5 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine12",
-            "from": [ 11.0, 0.0, 3.5 ], 
-            "to": [ 12.0, 1.0, 7.5 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 5.5 ], "axis": "y", "angle": -22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] }
-            }
-        },
-        {
-            "name": "Pine13",
-            "from": [ 11.0, 0.0, 3.5 ], 
-            "to": [ 12.0, 1.0, 7.5 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 5.5 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] }
-            }
-        },
-        {
-            "name": "Pine14",
-            "from": [ 9.5, 0.0, 5.0 ], 
-            "to": [ 13.5, 1.0, 6.0 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 5.5 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine15",
-            "from": [ 9.5, 0.0, 5.0 ], 
-            "to": [ 13.5, 1.0, 6.0 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 5.5 ], "axis": "y", "angle": -22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Stick1",
-            "from": [ 2.0, 0.0, 9.0 ], 
-            "to": [ 6.0, 1.0, 10.0 ], 
-            "rotation": { "origin": [ 6.0, 8.0, 7.0 ], "axis": "y", "angle": -45.0 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Stick2",
-            "from": [ 8.0, 0.0, 5.0 ], 
-            "to": [ 9.0, 1.0, 7.0 ], 
-            "rotation": { "origin": [ 6.0, 9.0, 7.0 ], "axis": "y", "angle": -45.0 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 2.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 2.0 ] }
-            }
-        },
-        {
-            "name": "Stick3",
-            "from": [ 14.0, 2.0, 12.0 ], 
-            "to": [ 15.0, 3.0, 17.0 ], 
-            "rotation": { "origin": [ 6.0, 9.0, 7.0 ], "axis": "x", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 5.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 5.0 ] }
-            }
-        },
-        {
-            "name": "Stick4",
-            "from": [ 8.0, 0.0, 12.0 ], 
-            "to": [ 9.0, 1.0, 13.0 ], 
-            "rotation": { "origin": [ 8.0, 8.0, 8.0 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] }
-            }
-        }
-    ]
+	"textures": {
+		"0": "block/oak_log",
+		"particle": "block/oak_log"
+	},
+	"elements": [
+		{
+			"name": "Pine1",
+			"from": [9, 1, 5],
+			"to": [14, 2, 6],
+			"rotation": {"angle": -45, "axis": "y", "origin": [11.5, 1, 5.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 5, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine2",
+			"from": [11, 1, 3],
+			"to": [12, 2, 8],
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 5], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 5], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine3",
+			"from": [9, 1, 5],
+			"to": [14, 2, 6],
+			"faces": {
+				"north": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 5, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine4",
+			"from": [9, 1, 5],
+			"to": [14, 2, 6],
+			"rotation": {"angle": 45, "axis": "y", "origin": [11.5, 1, 5.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 5, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine5",
+			"from": [11, 2, 3.5],
+			"to": [12, 3.1, 7.5],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [11.5, 1, 5.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 4], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 4], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine6",
+			"from": [11, 2, 3.5],
+			"to": [12, 3, 7.5],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [11.5, 1, 5.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 4], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 4], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine7",
+			"from": [9.5, 2, 5],
+			"to": [13.5, 3, 6],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [11.5, 1, 5.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 4, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine8",
+			"from": [9.5, 2, 5],
+			"to": [13.5, 2.9, 6],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [11.5, 1, 5.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 4, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine9",
+			"from": [10, 3, 5],
+			"to": [13, 3.9, 6],
+			"faces": {
+				"north": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 3, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine10",
+			"from": [11, 3, 4],
+			"to": [12, 4, 7],
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 3], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 3], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine11",
+			"from": [11, 4, 5],
+			"to": [12, 5, 6],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [11.5, 1, 5.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine12",
+			"from": [11, 0, 3.5],
+			"to": [12, 1, 7.5],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [11.5, 1, 5.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 4], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 4], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine13",
+			"from": [11, 0, 3.5],
+			"to": [12, 1, 7.5],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [11.5, 1, 5.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 4], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 4], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine14",
+			"from": [9.5, 0, 5],
+			"to": [13.5, 1, 6],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [11.5, 1, 5.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 4, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine15",
+			"from": [9.5, 0, 5],
+			"to": [13.5, 1, 6],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [11.5, 1, 5.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 4, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Stick1",
+			"from": [2, 0, 9],
+			"to": [6, 1, 10],
+			"rotation": {"angle": -45, "axis": "y", "origin": [6, 8, 7]},
+			"faces": {
+				"north": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 4, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Stick2",
+			"from": [8, 0, 5],
+			"to": [9, 1, 7],
+			"rotation": {"angle": -45, "axis": "y", "origin": [6, 9, 7]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 2], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 2], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Stick3",
+			"from": [14, 2, 12],
+			"to": [15, 3, 17],
+			"rotation": {"angle": 22.5, "axis": "x", "origin": [6, 9, 7]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 5], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 5], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Stick4",
+			"from": [8, 0, 12],
+			"to": [9, 1, 13],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [8, 8, 8]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 1], "texture": "#0"}
+			}
+		}
+	]
 }

--- a/src/main/resources/assets/projectvibrantjourneys/models/block/pinecones3.json
+++ b/src/main/resources/assets/projectvibrantjourneys/models/block/pinecones3.json
@@ -1,411 +1,412 @@
 {
+	"credit": "Made with Blockbench",
 	"parent": "block/thin_block",
-    "textures": {
-    	"particle": "block/oak_log",
-        "0": "block/oak_log"
-    },
-    "elements": [
-        {
-            "name": "Pine1",
-            "from": [ 9.0, 1.0, 5.0 ], 
-            "to": [ 14.0, 2.0, 6.0 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 5.5 ], "axis": "y", "angle": -45.0 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine2",
-            "from": [ 11.0, 1.0, 3.0 ], 
-            "to": [ 12.0, 2.0, 8.0 ], 
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 5.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 5.0 ] }
-            }
-        },
-        {
-            "name": "Pine3",
-            "from": [ 9.0, 1.0, 5.0 ], 
-            "to": [ 14.0, 2.0, 6.0 ], 
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine4",
-            "from": [ 9.0, 1.0, 5.0 ], 
-            "to": [ 14.0, 2.0, 6.0 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 5.5 ], "axis": "y", "angle": 45.0 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine5",
-            "from": [ 11.0, 2.0, 3.5 ], 
-            "to": [ 12.0, 3.0, 7.5 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 5.5 ], "axis": "y", "angle": -22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] }
-            }
-        },
-        {
-            "name": "Pine6",
-            "from": [ 11.0, 2.0, 3.5 ], 
-            "to": [ 12.0, 3.0, 7.5 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 5.5 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] }
-            }
-        },
-        {
-            "name": "Pine7",
-            "from": [ 9.5, 2.0, 5.0 ], 
-            "to": [ 13.5, 3.0, 6.0 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 5.5 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine8",
-            "from": [ 9.5, 2.0, 5.0 ], 
-            "to": [ 13.5, 3.0, 6.0 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 5.5 ], "axis": "y", "angle": -22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine9",
-            "from": [ 10.0, 3.0, 5.0 ], 
-            "to": [ 13.0, 4.0, 6.0 ], 
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine10",
-            "from": [ 11.0, 3.0, 4.0 ], 
-            "to": [ 12.0, 4.0, 7.0 ], 
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 3.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 3.0 ] }
-            }
-        },
-        {
-            "name": "Pine11",
-            "from": [ 11.0, 4.0, 5.0 ], 
-            "to": [ 12.0, 5.0, 6.0 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 5.5 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine12",
-            "from": [ 11.0, 0.0, 3.5 ], 
-            "to": [ 12.0, 1.0, 7.5 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 5.5 ], "axis": "y", "angle": -22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] }
-            }
-        },
-        {
-            "name": "Pine13",
-            "from": [ 11.0, 0.0, 3.5 ], 
-            "to": [ 12.0, 1.0, 7.5 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 5.5 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] }
-            }
-        },
-        {
-            "name": "Pine14",
-            "from": [ 9.5, 0.0, 5.0 ], 
-            "to": [ 13.5, 1.0, 6.0 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 5.5 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine15",
-            "from": [ 9.5, 0.0, 5.0 ], 
-            "to": [ 13.5, 1.0, 6.0 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 5.5 ], "axis": "y", "angle": -22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Stick1",
-            "from": [ 2.0, 0.0, 5.0 ], 
-            "to": [ 5.0, 1.0, 6.0 ], 
-            "rotation": { "origin": [ -4.0, 11.0, 14.0 ], "axis": "y", "angle": -22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Stick2",
-            "from": [ 8.0, 0.0, 11.0 ], 
-            "to": [ 9.0, 1.0, 14.0 ], 
-            "rotation": { "origin": [ 6.0, 9.0, 7.0 ], "axis": "y", "angle": -45.0 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 3.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 3.0 ] }
-            }
-        },
-        {
-            "name": "Stick3",
-            "from": [ 4.0, -1.0, 5.0 ], 
-            "to": [ 5.0, 0.0, 10.0 ], 
-            "rotation": { "origin": [ 6.0, 9.0, 7.0 ], "axis": "x", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 5.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 5.0 ] }
-            }
-        },
-        {
-            "name": "a",
-            "from": [ 10.0, 0.0, 11.0 ], 
-            "to": [ 13.0, 1.0, 12.0 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 10.5 ], "axis": "y", "angle": -22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "b",
-            "from": [ 9.5, 0.0, 11.0 ], 
-            "to": [ 13.5, 1.0, 12.0 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 11.5 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "c",
-            "from": [ 11.0, 0.0, 10.5 ], 
-            "to": [ 12.0, 1.0, 13.5 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 11.5 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 3.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 3.0 ] }
-            }
-        },
-        {
-            "name": "d",
-            "from": [ 11.0, 1.0, 9.5 ], 
-            "to": [ 12.0, 2.0, 13.5 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 11.5 ], "axis": "y", "angle": -22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] }
-            }
-        },
-        {
-            "name": "e",
-            "from": [ 11.0, 1.0, 9.5 ], 
-            "to": [ 12.0, 2.0, 13.5 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 10.5 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] }
-            }
-        },
-        {
-            "name": "f",
-            "from": [ 9.5, 1.0, 11.0 ], 
-            "to": [ 13.5, 2.0, 12.0 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 11.5 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "g",
-            "from": [ 9.5, 1.0, 11.0 ], 
-            "to": [ 13.5, 2.0, 12.0 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 11.5 ], "axis": "y", "angle": -22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "h",
-            "from": [ 10.0, 2.0, 11.0 ], 
-            "to": [ 12.0, 3.0, 12.0 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 11.5 ], "axis": "y", "angle": -22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "i",
-            "from": [ 10.0, 2.0, 11.0 ], 
-            "to": [ 13.0, 3.0, 12.0 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 11.5 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "j",
-            "from": [ 11.0, 2.0, 11.0 ], 
-            "to": [ 12.0, 3.0, 13.0 ], 
-            "rotation": { "origin": [ 10.5, 1.0, 11.5 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 2.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 2.0 ] }
-            }
-        },
-        {
-            "name": "k",
-            "from": [ 11.0, 3.0, 11.5 ], 
-            "to": [ 12.0, 4.0, 12.5 ], 
-            "rotation": { "origin": [ 10.5, 1.0, 11.5 ], "axis": "y", "angle": 45.0 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] }
-            }
-        }
-    ]
+	"textures": {
+		"0": "block/oak_log",
+		"particle": "block/oak_log"
+	},
+	"elements": [
+		{
+			"name": "Pine1",
+			"from": [9, 1, 5],
+			"to": [14, 2, 6],
+			"rotation": {"angle": -45, "axis": "y", "origin": [11.5, 1, 5.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 5, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine2",
+			"from": [11, 1, 3],
+			"to": [12, 2, 8],
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 5], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 5], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine3",
+			"from": [9, 1, 5],
+			"to": [14, 2, 6],
+			"faces": {
+				"north": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 5, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine4",
+			"from": [9, 1, 5],
+			"to": [14, 2, 6],
+			"rotation": {"angle": 45, "axis": "y", "origin": [11.5, 1, 5.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 5, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine5",
+			"from": [11, 2, 3.5],
+			"to": [12, 3, 7.5],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [11.5, 1, 5.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 4], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 4], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine6",
+			"from": [11, 2, 3.5],
+			"to": [12, 2.9, 7.5],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [11.5, 1, 5.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 4], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 4], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine7",
+			"from": [9.5, 2, 5],
+			"to": [13.5, 3.1, 6],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [11.5, 1, 5.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 4, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine8",
+			"from": [9.5, 2, 5],
+			"to": [13.5, 3, 6],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [11.5, 1, 5.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 4, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine9",
+			"from": [10, 3, 5],
+			"to": [13, 4, 6],
+			"faces": {
+				"north": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 3, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine10",
+			"from": [11, 3, 4],
+			"to": [12, 3.9, 7],
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 3], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 3], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine11",
+			"from": [11, 4, 5],
+			"to": [12, 5, 6],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [11.5, 1, 5.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine12",
+			"from": [11, 0, 3.5],
+			"to": [12, 1, 7.5],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [11.5, 1, 5.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 4], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 4], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine13",
+			"from": [11, 0, 3.5],
+			"to": [12, 1, 7.5],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [11.5, 1, 5.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 4], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 4], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine14",
+			"from": [9.5, 0, 5],
+			"to": [13.5, 1, 6],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [11.5, 1, 5.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 4, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine15",
+			"from": [9.5, 0, 5],
+			"to": [13.5, 1, 6],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [11.5, 1, 5.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 4, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Stick1",
+			"from": [2, 0, 5],
+			"to": [5, 1, 6],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [-4, 11, 14]},
+			"faces": {
+				"north": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 3, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Stick2",
+			"from": [8, 0, 11],
+			"to": [9, 1, 14],
+			"rotation": {"angle": -45, "axis": "y", "origin": [6, 9, 7]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 3], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 3], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Stick3",
+			"from": [4, -1, 5],
+			"to": [5, 0, 10],
+			"rotation": {"angle": 22.5, "axis": "x", "origin": [6, 9, 7]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 5], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 5], "texture": "#0"}
+			}
+		},
+		{
+			"name": "a",
+			"from": [10, 0, 11],
+			"to": [13, 1, 12],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [11.5, 1, 10.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 3, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "b",
+			"from": [9.5, 0, 11],
+			"to": [13.5, 1, 12],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [11.5, 1, 11.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 4, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "c",
+			"from": [11, 0, 10.5],
+			"to": [12, 1, 13.5],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [11.5, 1, 11.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 3], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 3], "texture": "#0"}
+			}
+		},
+		{
+			"name": "d",
+			"from": [11, 1, 9.5],
+			"to": [12, 2, 13.5],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [11.5, 1, 11.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 4], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 4], "texture": "#0"}
+			}
+		},
+		{
+			"name": "e",
+			"from": [11, 1, 9.5],
+			"to": [12, 1.9, 13.5],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [11.5, 1, 10.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 4], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 4], "texture": "#0"}
+			}
+		},
+		{
+			"name": "f",
+			"from": [9.5, 1, 11],
+			"to": [13.5, 2, 12],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [11.5, 1, 11.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 4, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "g",
+			"from": [9.5, 1, 11],
+			"to": [13.5, 2, 12],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [11.5, 1, 11.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 4, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "h",
+			"from": [10, 2, 11],
+			"to": [12, 3.1, 12],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [11.5, 1, 11.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 2, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "i",
+			"from": [10, 2, 11],
+			"to": [13, 3, 12],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [11.5, 1, 11.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 3, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "j",
+			"from": [11, 2, 11],
+			"to": [12, 2.9, 13],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [10.5, 1, 11.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 2], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 2], "texture": "#0"}
+			}
+		},
+		{
+			"name": "k",
+			"from": [10.7, 3, 11.7],
+			"to": [11.7, 4, 12.7],
+			"rotation": {"angle": 45, "axis": "y", "origin": [10.5, 1, 11.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 1], "texture": "#0"}
+			}
+		}
+	]
 }

--- a/src/main/resources/assets/projectvibrantjourneys/models/block/pinecones4.json
+++ b/src/main/resources/assets/projectvibrantjourneys/models/block/pinecones4.json
@@ -1,215 +1,216 @@
 {
+	"credit": "Made with Blockbench",
 	"parent": "block/thin_block",
-    "textures": {
-    	"particle": "block/oak_log",
-        "0": "block/oak_log"
-    },
-    "elements": [
-        {
-            "name": "Pine1",
-            "from": [ 9.0, 1.0, 10.0 ], 
-            "to": [ 14.0, 2.0, 11.0 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 10.5 ], "axis": "y", "angle": -45.0 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine2",
-            "from": [ 11.0, 1.0, 8.0 ], 
-            "to": [ 12.0, 2.0, 13.0 ], 
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 5.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 5.0 ] }
-            }
-        },
-        {
-            "name": "Pine3",
-            "from": [ 9.0, 1.0, 10.0 ], 
-            "to": [ 14.0, 2.0, 11.0 ], 
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine4",
-            "from": [ 9.0, 1.0, 10.0 ], 
-            "to": [ 14.0, 2.0, 11.0 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 10.5 ], "axis": "y", "angle": 45.0 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 5.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine5",
-            "from": [ 11.0, 2.0, 8.5 ], 
-            "to": [ 12.0, 3.0, 12.5 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 10.5 ], "axis": "y", "angle": -22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] }
-            }
-        },
-        {
-            "name": "Pine6",
-            "from": [ 11.0, 2.0, 8.5 ], 
-            "to": [ 12.0, 3.0, 12.5 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 10.5 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] }
-            }
-        },
-        {
-            "name": "Pine7",
-            "from": [ 9.5, 2.0, 10.0 ], 
-            "to": [ 13.5, 3.0, 11.0 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 10.5 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine8",
-            "from": [ 9.5, 2.0, 10.0 ], 
-            "to": [ 13.5, 3.0, 11.0 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 10.5 ], "axis": "y", "angle": -22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine9",
-            "from": [ 10.0, 3.0, 10.0 ], 
-            "to": [ 13.0, 4.0, 11.0 ], 
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine10",
-            "from": [ 11.0, 3.0, 9.0 ], 
-            "to": [ 12.0, 4.0, 12.0 ], 
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 3.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 3.0 ] }
-            }
-        },
-        {
-            "name": "Pine11",
-            "from": [ 11.0, 4.0, 10.0 ], 
-            "to": [ 12.0, 5.0, 11.0 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 10.5 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine12",
-            "from": [ 11.0, 0.0, 8.5 ], 
-            "to": [ 12.0, 1.0, 12.5 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 10.5 ], "axis": "y", "angle": -22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] }
-            }
-        },
-        {
-            "name": "Pine13",
-            "from": [ 11.0, 0.0, 8.5 ], 
-            "to": [ 12.0, 1.0, 12.5 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 10.5 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 4.0 ] }
-            }
-        },
-        {
-            "name": "Pine14",
-            "from": [ 9.5, 0.0, 10.0 ], 
-            "to": [ 13.5, 1.0, 11.0 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 10.5 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Pine15",
-            "from": [ 9.5, 0.0, 10.0 ], 
-            "to": [ 13.5, 1.0, 11.0 ], 
-            "rotation": { "origin": [ 11.5, 1.0, 10.5 ], "axis": "y", "angle": -22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] }
-            }
-        }
-    ]
+	"textures": {
+		"0": "block/oak_log",
+		"particle": "block/oak_log"
+	},
+	"elements": [
+		{
+			"name": "Pine1",
+			"from": [9, 1, 10],
+			"to": [14, 2, 11],
+			"rotation": {"angle": -45, "axis": "y", "origin": [11.5, 1, 10.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 5, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine2",
+			"from": [11, 1, 8],
+			"to": [12, 2, 13],
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 5], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 5], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine3",
+			"from": [9, 1, 10],
+			"to": [14, 2, 11],
+			"faces": {
+				"north": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 5, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine4",
+			"from": [9, 1, 10],
+			"to": [14, 2, 11],
+			"rotation": {"angle": 45, "axis": "y", "origin": [11.5, 1, 10.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 5, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 5, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine5",
+			"from": [11, 2, 8.5],
+			"to": [12, 3, 12.5],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [11.5, 1, 10.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 4], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 4], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine6",
+			"from": [11, 2, 8.5],
+			"to": [12, 3.1, 12.5],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [11.5, 1, 10.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 4], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 4], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine7",
+			"from": [9.5, 2, 10],
+			"to": [13.5, 2.9, 11],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [11.5, 1, 10.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 4, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine8",
+			"from": [9.5, 2, 10],
+			"to": [13.5, 3, 11],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [11.5, 1, 10.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 4, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine9",
+			"from": [10, 3, 10],
+			"to": [13, 3.9, 11],
+			"faces": {
+				"north": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 3, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine10",
+			"from": [11, 3, 9],
+			"to": [12, 4, 12],
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 3], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 3], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine11",
+			"from": [11, 4, 10],
+			"to": [12, 5, 11],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [11.5, 1, 10.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine12",
+			"from": [11, 0, 8.5],
+			"to": [12, 1, 12.5],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [11.5, 1, 10.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 4], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 4], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine13",
+			"from": [11, 0, 8.5],
+			"to": [12, 1, 12.5],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [11.5, 1, 10.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 4], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 4], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine14",
+			"from": [9.5, 0, 10],
+			"to": [13.5, 1, 11],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [11.5, 1, 10.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 4, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Pine15",
+			"from": [9.5, 0, 10],
+			"to": [13.5, 1, 11],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [11.5, 1, 10.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 4, 1], "texture": "#0"}
+			}
+		}
+	]
 }

--- a/src/main/resources/assets/projectvibrantjourneys/models/block/seashells0.json
+++ b/src/main/resources/assets/projectvibrantjourneys/models/block/seashells0.json
@@ -1,150 +1,151 @@
 {
+	"credit": "Made with Blockbench",
 	"parent": "block/thin_block",
-    "textures": {
-    	"particle": "block/diorite",
-        "0": "block/granite",
-        "1": "block/diorite",
-        "2": "block/obsidian"
-    },
-    "elements": [
-        {
-            "name": "Shell1",
-            "from": [ 4.0, 0.0, 4.0 ], 
-            "to": [ 6.0, 1.0, 7.0 ], 
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 1.0, 6.0, 2.0, 7.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 3.0 ] }
-            }
-        },
-        {
-            "name": "Shell2",
-            "from": [ 4.0, 0.0, 4.0 ], 
-            "to": [ 6.0, 1.0, 5.0 ], 
-            "rotation": { "origin": [ 5.0, 8.0, 6.0 ], "axis": "y", "angle": -22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 1.0, 1.0, 6.0, 7.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 1.0, 6.0, 2.0, 7.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Shell3",
-            "from": [ 4.0, 0.0, 4.0 ], 
-            "to": [ 6.0, 1.0, 5.0 ], 
-            "rotation": { "origin": [ 5.0, 8.0, 6.0 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 1.0, 6.0, 2.0, 7.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Shell4",
-            "from": [ 4.0, 0.0, 4.0 ], 
-            "to": [ 6.0, 1.0, 6.0 ], 
-            "rotation": { "origin": [ 5.0, 8.0, 6.0 ], "axis": "y", "angle": 45.0 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 1.0, 6.0, 2.0, 7.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 2.0 ] }
-            }
-        },
-        {
-            "name": "Shell5",
-            "from": [ 4.0, 0.0, 4.0 ], 
-            "to": [ 6.0, 1.0, 6.0 ], 
-            "rotation": { "origin": [ 5.0, 8.0, 6.0 ], "axis": "y", "angle": -45.0 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 1.0, 6.0, 2.0, 7.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 2.0 ] }
-            }
-        },
-        {
-            "name": "Random1",
-            "from": [ 11.0, 0.0, 3.0 ], 
-            "to": [ 12.0, 1.0, 4.0 ], 
-            "rotation": { "origin": [ 8.0, 8.0, 8.0 ], "axis": "y", "angle": -22.5 },
-            "faces": {
-                "north": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#1", "uv": [ 3.0, 2.0, 4.0, 3.0 ] },
-                "down": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Random2",
-            "from": [ 7.0, 0.0, 10.0 ], 
-            "to": [ 8.0, 1.0, 12.0 ], 
-            "rotation": { "origin": [ 8.0, 8.0, 8.0 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#1", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "south": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#1", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "up": { "texture": "#1", "uv": [ 8.0, 7.0, 9.0, 9.0 ] },
-                "down": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 2.0 ] }
-            }
-        },
-        {
-            "name": "Random3",
-            "from": [ 1.0, 2.0, 9.0 ], 
-            "to": [ 2.0, 3.0, 10.0 ], 
-            "rotation": { "origin": [ 8.0, 8.0, 8.0 ], "axis": "z", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#1", "uv": [ 2.0, 6.0, 3.0, 7.0 ] },
-                "east": { "texture": "#1", "uv": [ 4.0, 9.0, 5.0, 10.0 ] },
-                "south": { "texture": "#1", "uv": [ 2.0, 4.0, 3.0, 5.0 ] },
-                "west": { "texture": "#1", "uv": [ 15.0, 9.0, 16.0, 10.0 ] },
-                "up": { "texture": "#1", "uv": [ 6.0, 0.0, 7.0, 1.0 ] },
-                "down": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Random4",
-            "from": [ 10.0, -2.0, 12.0 ], 
-            "to": [ 11.0, 0.0, 13.0 ], 
-            "rotation": { "origin": [ 8.0, 8.0, 8.0 ], "axis": "z", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 2.0 ] },
-                "east": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 2.0 ] },
-                "south": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 2.0 ] },
-                "west": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 2.0 ] },
-                "up": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "down": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Random5",
-            "from": [ 3.0, 1.0, 12.0 ], 
-            "to": [ 5.0, 2.0, 14.0 ], 
-            "rotation": { "origin": [ 8.0, 8.0, 8.0 ], "axis": "z", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#2", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "east": { "texture": "#2", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "south": { "texture": "#2", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "west": { "texture": "#2", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "up": { "texture": "#2", "uv": [ 1.0, 2.0, 3.0, 4.0 ] },
-                "down": { "texture": "#2", "uv": [ 0.0, 0.0, 2.0, 2.0 ] }
-            }
-        }
-    ]
+	"textures": {
+		"0": "block/granite",
+		"1": "block/diorite",
+		"2": "block/obsidian",
+		"particle": "block/diorite"
+	},
+	"elements": [
+		{
+			"name": "Shell1",
+			"from": [4, 0, 4],
+			"to": [6, 1, 7],
+			"faces": {
+				"north": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"up": {"uv": [1, 6, 2, 7], "texture": "#0"},
+				"down": {"uv": [0, 0, 2, 3], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Shell2",
+			"from": [4, 0, 4],
+			"to": [6, 0.9, 5],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [5, 8, 6]},
+			"faces": {
+				"north": {"uv": [1, 1, 6, 7], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [1, 6, 2, 7], "texture": "#0"},
+				"down": {"uv": [0, 0, 2, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Shell3",
+			"from": [4, 0, 4],
+			"to": [6, 0.9, 5],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [5, 8, 6]},
+			"faces": {
+				"north": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [1, 6, 2, 7], "texture": "#0"},
+				"down": {"uv": [0, 0, 2, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Shell4",
+			"from": [4, 0, 4],
+			"to": [6, 0.8, 6],
+			"rotation": {"angle": 45, "axis": "y", "origin": [5, 8, 6]},
+			"faces": {
+				"north": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"up": {"uv": [1, 6, 2, 7], "texture": "#0"},
+				"down": {"uv": [0, 0, 2, 2], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Shell5",
+			"from": [4, 0, 4],
+			"to": [6, 0.8, 6],
+			"rotation": {"angle": -45, "axis": "y", "origin": [5, 8, 6]},
+			"faces": {
+				"north": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"up": {"uv": [1, 6, 2, 7], "texture": "#0"},
+				"down": {"uv": [0, 0, 2, 2], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Random1",
+			"from": [11, 0, 3],
+			"to": [12, 1, 4],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [8, 8, 8]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#1"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#1"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#1"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#1"},
+				"up": {"uv": [3, 2, 4, 3], "texture": "#1"},
+				"down": {"uv": [0, 0, 1, 1], "texture": "#1"}
+			}
+		},
+		{
+			"name": "Random2",
+			"from": [7, 0, 10],
+			"to": [8, 1, 12],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [8, 8, 8]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#1"},
+				"east": {"uv": [0, 0, 2, 1], "texture": "#1"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#1"},
+				"west": {"uv": [0, 0, 2, 1], "texture": "#1"},
+				"up": {"uv": [8, 7, 9, 9], "texture": "#1"},
+				"down": {"uv": [0, 0, 1, 2], "texture": "#1"}
+			}
+		},
+		{
+			"name": "Random3",
+			"from": [1, 2, 9],
+			"to": [2, 3, 10],
+			"rotation": {"angle": 22.5, "axis": "z", "origin": [8, 8, 8]},
+			"faces": {
+				"north": {"uv": [2, 6, 3, 7], "texture": "#1"},
+				"east": {"uv": [4, 9, 5, 10], "texture": "#1"},
+				"south": {"uv": [2, 4, 3, 5], "texture": "#1"},
+				"west": {"uv": [15, 9, 16, 10], "texture": "#1"},
+				"up": {"uv": [6, 0, 7, 1], "texture": "#1"},
+				"down": {"uv": [0, 0, 1, 1], "texture": "#1"}
+			}
+		},
+		{
+			"name": "Random4",
+			"from": [10, -2, 12],
+			"to": [11, 0, 13],
+			"rotation": {"angle": 22.5, "axis": "z", "origin": [8, 8, 8]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 2], "texture": "#1"},
+				"east": {"uv": [0, 0, 1, 2], "texture": "#1"},
+				"south": {"uv": [0, 0, 1, 2], "texture": "#1"},
+				"west": {"uv": [0, 0, 1, 2], "texture": "#1"},
+				"up": {"uv": [0, 0, 1, 1], "texture": "#1"},
+				"down": {"uv": [0, 0, 1, 1], "texture": "#1"}
+			}
+		},
+		{
+			"name": "Random5",
+			"from": [3, 1, 12],
+			"to": [5, 2, 14],
+			"rotation": {"angle": 22.5, "axis": "z", "origin": [8, 8, 8]},
+			"faces": {
+				"north": {"uv": [0, 0, 2, 1], "texture": "#2"},
+				"east": {"uv": [0, 0, 2, 1], "texture": "#2"},
+				"south": {"uv": [0, 0, 2, 1], "texture": "#2"},
+				"west": {"uv": [0, 0, 2, 1], "texture": "#2"},
+				"up": {"uv": [1, 2, 3, 4], "texture": "#2"},
+				"down": {"uv": [0, 0, 2, 2], "texture": "#2"}
+			}
+		}
+	]
 }

--- a/src/main/resources/assets/projectvibrantjourneys/models/block/seashells1.json
+++ b/src/main/resources/assets/projectvibrantjourneys/models/block/seashells1.json
@@ -1,176 +1,164 @@
 {
+	"credit": "Made with Blockbench",
 	"parent": "block/thin_block",
-    "textures": {
-    	"particle": "block/diorite",
-        "0": "block/diorite",
-        "1": "block/granite",
-        "2": "block/prismarine_bricks"
-    },
-    "elements": [
-        {
-            "name": "Shell1",
-            "from": [ 10.0, 0.0, 4.0 ], 
-            "to": [ 12.0, 1.0, 7.0 ], 
-            "rotation": { "origin": [ 11.0, 8.0, 6.0 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 1.0, 1.0, 2.0, 2.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 3.0 ] }
-            }
-        },
-        {
-            "name": "Shell2",
-            "from": [ 10.0, 0.0, 4.0 ], 
-            "to": [ 12.0, 1.0, 7.0 ], 
-            "rotation": { "origin": [ 11.0, 8.0, 6.0 ], "axis": "y", "angle": -22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 1.0, 1.0, 2.0, 2.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 3.0 ] }
-            }
-        },
-        {
-            "name": "Shell3",
-            "from": [ 10.0, 0.0, 4.0 ], 
-            "to": [ 12.0, 1.0, 7.0 ], 
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 1.0, 1.0, 2.0, 2.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 3.0 ] }
-            }
-        },
-        {
-            "name": "Shell4",
-            "from": [ 10.0, 0.0, 4.0 ], 
-            "to": [ 12.0, 1.0, 8.0 ], 
-            "rotation": { "origin": [ 11.0, 8.0, 6.0 ], "axis": "y", "angle": 45.0 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 1.0, 1.0, 2.0, 2.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 4.0 ] }
-            }
-        },
-        {
-            "name": "Shell5",
-            "from": [ 10.0, 0.0, 4.0 ], 
-            "to": [ 12.0, 1.0, 8.0 ], 
-            "rotation": { "origin": [ 11.0, 8.0, 6.0 ], "axis": "y", "angle": -45.0 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 1.0, 1.0, 2.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 4.0 ] }
-            }
-        },
-        {
-            "name": "Shell6",
-            "from": [ 10.0, 0.0, 6.0 ], 
-            "to": [ 12.0, 1.0, 8.0 ], 
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 1.0, 1.0, 2.0, 2.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 2.0 ] }
-            }
-        },
-        {
-            "name": "Shell7",
-            "from": [ 2.0, -2.0, 4.0 ], 
-            "to": [ 6.0, -1.0, 8.0 ], 
-            "rotation": { "origin": [ 8.0, 8.0, 8.0 ], "axis": "x", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#1", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "east": { "texture": "#1", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "south": { "texture": "#1", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "west": { "texture": "#1", "uv": [ 0.0, 0.0, 4.0, 1.0 ] },
-                "up": { "texture": "#1", "uv": [ 0.0, 0.0, 4.0, 4.0 ] },
-                "down": { "texture": "#1", "uv": [ 0.0, 0.0, 4.0, 4.0 ] }
-            }
-        },
-        {
-            "name": "Shell8",
-            "from": [ 3.0, -1.0, 5.0 ], 
-            "to": [ 5.0, 0.0, 7.0 ], 
-            "rotation": { "origin": [ 8.0, 8.0, 8.0 ], "axis": "x", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#1", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "east": { "texture": "#1", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "south": { "texture": "#1", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "west": { "texture": "#1", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "up": { "texture": "#1", "uv": [ 0.0, 0.0, 2.0, 2.0 ] },
-                "down": { "texture": "#1", "uv": [ 0.0, 0.0, 2.0, 2.0 ] }
-            }
-        },
-        {
-            "name": "Shell9",
-            "from": [ 3.5, 0.0, 5.5 ], 
-            "to": [ 4.5, 1.0, 6.5 ], 
-            "rotation": { "origin": [ 8.0, 8.0, 8.0 ], "axis": "x", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "down": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Random1",
-            "from": [ 4.0, -2.0, 9.0 ], 
-            "to": [ 9.0, -1.0, 10.0 ], 
-            "rotation": { "origin": [ 8.0, 8.0, 8.0 ], "axis": "z", "angle": -22.5 },
-            "faces": {
-                "north": { "texture": "#2", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "east": { "texture": "#2", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#2", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "west": { "texture": "#2", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#2", "uv": [ 0.0, 0.0, 5.0, 1.0 ] },
-                "down": { "texture": "#2", "uv": [ 0.0, 0.0, 5.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Random2",
-            "from": [ 11.0, 3.0, 15.0 ], 
-            "to": [ 13.0, 4.0, 17.0 ], 
-            "rotation": { "origin": [ 8.0, 8.0, 8.0 ], "axis": "x", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#2", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "east": { "texture": "#2", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "south": { "texture": "#2", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "west": { "texture": "#2", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "up": { "texture": "#2", "uv": [ 0.0, 0.0, 2.0, 2.0 ] },
-                "down": { "texture": "#2", "uv": [ 0.0, 0.0, 2.0, 2.0 ] }
-            }
-        },
-        {
-            "name": "Random3",
-            "from": [ 4.0, 0.0, 11.0 ], 
-            "to": [ 6.0, 1.0, 12.0 ], 
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] }
-            }
-        }
-    ]
+	"textures": {
+		"0": "block/diorite",
+		"1": "block/granite",
+		"2": "block/prismarine_bricks",
+		"particle": "block/diorite"
+	},
+	"elements": [
+		{
+			"name": "Shell1",
+			"from": [10, 0, 4],
+			"to": [12, 0.8, 7],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [11, 8, 6]},
+			"faces": {
+				"north": {"uv": [0, 0, 2, 0.8], "texture": "#0"},
+				"east": {"uv": [0, 0, 3, 0.8], "texture": "#0"},
+				"south": {"uv": [0, 0, 2, 0.8], "texture": "#0"},
+				"west": {"uv": [0, 0, 3, 0.8], "texture": "#0"},
+				"up": {"uv": [1, 1, 3, 4], "texture": "#0"},
+				"down": {"uv": [0, 0, 2, 3], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Shell2",
+			"from": [10, 0, 4],
+			"to": [12, 0.7, 7],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [11, 8, 6]},
+			"faces": {
+				"north": {"uv": [0, 0, 2, 0.7], "texture": "#0"},
+				"east": {"uv": [0, 0, 3, 0.7], "texture": "#0"},
+				"south": {"uv": [0, 0, 2, 0.7], "texture": "#0"},
+				"west": {"uv": [0, 0, 3, 0.7], "texture": "#0"},
+				"up": {"uv": [1, 1, 3, 4], "texture": "#0"},
+				"down": {"uv": [0, 0, 2, 3], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Shell3",
+			"from": [10, 0, 4],
+			"to": [12, 1, 8],
+			"faces": {
+				"north": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"up": {"uv": [1, 1, 3, 5], "texture": "#0"},
+				"down": {"uv": [0, 0, 2, 4], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Shell4",
+			"from": [10, 0, 4],
+			"to": [12, 0.9, 8],
+			"rotation": {"angle": 45, "axis": "y", "origin": [11, 8, 6]},
+			"faces": {
+				"north": {"uv": [0, 0, 2, 0.9], "texture": "#0"},
+				"east": {"uv": [0, 0, 4, 0.9], "texture": "#0"},
+				"south": {"uv": [0, 0, 2, 0.9], "texture": "#0"},
+				"west": {"uv": [0, 0, 4, 0.9], "texture": "#0"},
+				"up": {"uv": [1, 1, 3, 5], "texture": "#0"},
+				"down": {"uv": [0, 0, 2, 4], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Shell5",
+			"from": [10, 0, 4],
+			"to": [12, 0.8, 8],
+			"rotation": {"angle": -45, "axis": "y", "origin": [11, 8, 6]},
+			"faces": {
+				"north": {"uv": [0, 0, 2, 0.8], "texture": "#0"},
+				"east": {"uv": [0, 0, 4, 0.8], "texture": "#0"},
+				"south": {"uv": [0, 0, 2, 0.8], "texture": "#0"},
+				"west": {"uv": [0, 0, 4, 0.8], "texture": "#0"},
+				"up": {"uv": [1, 1, 3, 5], "texture": "#0"},
+				"down": {"uv": [0, 0, 2, 4], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Shell7",
+			"from": [2, -2, 4],
+			"to": [6, -1, 8],
+			"rotation": {"angle": 22.5, "axis": "x", "origin": [8, 8, 8]},
+			"faces": {
+				"north": {"uv": [0, 0, 4, 1], "texture": "#1"},
+				"east": {"uv": [0, 0, 4, 1], "texture": "#1"},
+				"south": {"uv": [0, 0, 4, 1], "texture": "#1"},
+				"west": {"uv": [0, 0, 4, 1], "texture": "#1"},
+				"up": {"uv": [0, 0, 4, 4], "texture": "#1"},
+				"down": {"uv": [0, 0, 4, 4], "texture": "#1"}
+			}
+		},
+		{
+			"name": "Shell8",
+			"from": [3, -1, 5],
+			"to": [5, 0, 7],
+			"rotation": {"angle": 22.5, "axis": "x", "origin": [8, 8, 8]},
+			"faces": {
+				"north": {"uv": [0, 0, 2, 1], "texture": "#1"},
+				"east": {"uv": [0, 0, 2, 1], "texture": "#1"},
+				"south": {"uv": [0, 0, 2, 1], "texture": "#1"},
+				"west": {"uv": [0, 0, 2, 1], "texture": "#1"},
+				"up": {"uv": [0, 0, 2, 2], "texture": "#1"},
+				"down": {"uv": [0, 0, 2, 2], "texture": "#1"}
+			}
+		},
+		{
+			"name": "Shell9",
+			"from": [3.5, 0, 5.5],
+			"to": [4.5, 1, 6.5],
+			"rotation": {"angle": 22.5, "axis": "x", "origin": [8, 8, 8]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#1"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#1"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#1"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#1"},
+				"up": {"uv": [0, 0, 1, 1], "texture": "#1"},
+				"down": {"uv": [0, 0, 1, 1], "texture": "#1"}
+			}
+		},
+		{
+			"name": "Random1",
+			"from": [4, -2, 9],
+			"to": [9, -1, 10],
+			"rotation": {"angle": -22.5, "axis": "z", "origin": [8, 8, 8]},
+			"faces": {
+				"north": {"uv": [0, 0, 5, 1], "texture": "#2"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#2"},
+				"south": {"uv": [0, 0, 5, 1], "texture": "#2"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#2"},
+				"up": {"uv": [0, 0, 5, 1], "texture": "#2"},
+				"down": {"uv": [0, 0, 5, 1], "texture": "#2"}
+			}
+		},
+		{
+			"name": "Random2",
+			"from": [11, 3, 15],
+			"to": [13, 4, 17],
+			"rotation": {"angle": 22.5, "axis": "x", "origin": [8, 8, 8]},
+			"faces": {
+				"north": {"uv": [0, 0, 2, 1], "texture": "#2"},
+				"east": {"uv": [0, 0, 2, 1], "texture": "#2"},
+				"south": {"uv": [0, 0, 2, 1], "texture": "#2"},
+				"west": {"uv": [0, 0, 2, 1], "texture": "#2"},
+				"up": {"uv": [0, 0, 2, 2], "texture": "#2"},
+				"down": {"uv": [0, 0, 2, 2], "texture": "#2"}
+			}
+		},
+		{
+			"name": "Random3",
+			"from": [4, 0, 11],
+			"to": [6, 1, 12],
+			"faces": {
+				"north": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 2, 1], "texture": "#0"}
+			}
+		}
+	]
 }

--- a/src/main/resources/assets/projectvibrantjourneys/models/block/seashells4.json
+++ b/src/main/resources/assets/projectvibrantjourneys/models/block/seashells4.json
@@ -1,122 +1,123 @@
 {
+	"credit": "Made with Blockbench",
 	"parent": "block/thin_block",
-    "textures": {
-    	"particle": "block/diorite",
-        "0": "block/prismarine_bricks",
-        "1": "block/granite",
-        "2": "block/diorite",
-        "3": "block/green_wool"
-    },
-    "elements": [
-        {
-            "name": "Star1",
-            "from": [ 6.0, 0.0, 6.0 ], 
-            "to": [ 7.0, 1.0, 7.0 ], 
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Star2",
-            "from": [ 5.0, 0.0, 5.0 ], 
-            "to": [ 6.0, 1.0, 8.0 ], 
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 3.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 3.0 ] }
-            }
-        },
-        {
-            "name": "Star3",
-            "from": [ 5.0, 0.0, 6.0 ], 
-            "to": [ 6.0, 1.0, 8.0 ], 
-            "rotation": { "origin": [ 5.5, 8.0, 6.5 ], "axis": "y", "angle": -45.0 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 2.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 2.0 ] }
-            }
-        },
-        {
-            "name": "Star4",
-            "from": [ 5.0, 0.0, 5.0 ], 
-            "to": [ 6.0, 1.0, 7.0 ], 
-            "rotation": { "origin": [ 5.5, 8.0, 6.5 ], "axis": "y", "angle": 45.0 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
-                "up": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 2.0 ] },
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 2.0 ] }
-            }
-        },
-        {
-            "name": "Random1",
-            "from": [ 0.0, -1.0, 8.0 ], 
-            "to": [ 3.0, 0.0, 9.0 ], 
-            "rotation": { "origin": [ 5.0, 8.0, 5.0 ], "axis": "z", "angle": 45.0 },
-            "faces": {
-                "north": { "texture": "#1", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "east": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "south": { "texture": "#1", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "west": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "up": { "texture": "#1", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "down": { "texture": "#1", "uv": [ 0.0, 0.0, 3.0, 1.0 ] }
-            }
-        },
-        {
-            "name": "Random2",
-            "from": [ 2.0, 0.0, 11.0 ], 
-            "to": [ 6.0, 2.0, 14.0 ], 
-            "rotation": { "origin": [ 8.0, 8.0, 8.0 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#2", "uv": [ 0.0, 0.0, 4.0, 2.0 ] },
-                "east": { "texture": "#2", "uv": [ 0.0, 0.0, 3.0, 2.0 ] },
-                "south": { "texture": "#2", "uv": [ 0.0, 0.0, 4.0, 2.0 ] },
-                "west": { "texture": "#2", "uv": [ 0.0, 0.0, 3.0, 2.0 ] },
-                "up": { "texture": "#2", "uv": [ 0.0, 0.0, 4.0, 3.0 ] },
-                "down": { "texture": "#2", "uv": [ 0.0, 0.0, 4.0, 3.0 ] }
-            }
-        },
-        {
-            "name": "Random3",
-            "from": [ 6.0, 0.0, 11.0 ], 
-            "to": [ 8.0, 2.0, 13.0 ], 
-            "rotation": { "origin": [ 8.0, 8.0, 8.0 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#2", "uv": [ 0.0, 0.0, 2.0, 2.0 ] },
-                "east": { "texture": "#2", "uv": [ 0.0, 0.0, 2.0, 2.0 ] },
-                "south": { "texture": "#2", "uv": [ 0.0, 0.0, 2.0, 2.0 ] },
-                "west": { "texture": "#2", "uv": [ 0.0, 0.0, 2.0, 2.0 ] },
-                "up": { "texture": "#2", "uv": [ 0.0, 0.0, 2.0, 2.0 ] },
-                "down": { "texture": "#2", "uv": [ 0.0, 0.0, 2.0, 2.0 ] }
-            }
-        },
-        {
-            "name": "Random4",
-            "from": [ 13.0, 0.0, 10.0 ], 
-            "to": [ 14.0, 1.0, 13.0 ], 
-            "rotation": { "origin": [ 8.0, 8.0, 8.0 ], "axis": "x", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#3", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "east": { "texture": "#3", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "south": { "texture": "#3", "uv": [ 0.0, 0.0, 1.0, 1.0 ] },
-                "west": { "texture": "#3", "uv": [ 0.0, 0.0, 2.0, 3.0 ] },
-                "up": { "texture": "#3", "uv": [ 0.0, -1.0, 1.0, 2.0 ] },
-                "down": { "texture": "#3", "uv": [ 0.0, 0.0, 1.0, 3.0 ] }
-            }
-        }
-    ]
+	"textures": {
+		"0": "block/prismarine_bricks",
+		"1": "block/granite",
+		"2": "block/diorite",
+		"3": "block/green_wool",
+		"particle": "block/diorite"
+	},
+	"elements": [
+		{
+			"name": "Star1",
+			"from": [6, 0, 6],
+			"to": [7, 1, 7],
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Star2",
+			"from": [5, 0, 5],
+			"to": [6, 1, 8],
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 3], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 3], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Star3",
+			"from": [5, 0, 6],
+			"to": [6, 0.9, 8],
+			"rotation": {"angle": -45, "axis": "y", "origin": [5.5, 8, 6.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 2], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 2], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Star4",
+			"from": [5, 0, 5],
+			"to": [6, 0.9, 6],
+			"rotation": {"angle": 45, "axis": "y", "origin": [5.5, 8, 6.5]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 0.9], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 0.9], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 0.9], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Random1",
+			"from": [0, -1, 8],
+			"to": [3, 0, 9],
+			"rotation": {"angle": 45, "axis": "z", "origin": [5, 8, 5]},
+			"faces": {
+				"north": {"uv": [0, 0, 3, 1], "texture": "#1"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#1"},
+				"south": {"uv": [0, 0, 3, 1], "texture": "#1"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#1"},
+				"up": {"uv": [0, 0, 3, 1], "texture": "#1"},
+				"down": {"uv": [0, 0, 3, 1], "texture": "#1"}
+			}
+		},
+		{
+			"name": "Random2",
+			"from": [2, 0, 11],
+			"to": [6, 2, 14],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [8, 8, 8]},
+			"faces": {
+				"north": {"uv": [0, 0, 4, 2], "texture": "#2"},
+				"east": {"uv": [0, 0, 3, 2], "texture": "#2"},
+				"south": {"uv": [0, 0, 4, 2], "texture": "#2"},
+				"west": {"uv": [0, 0, 3, 2], "texture": "#2"},
+				"up": {"uv": [0, 0, 4, 3], "texture": "#2"},
+				"down": {"uv": [0, 0, 4, 3], "texture": "#2"}
+			}
+		},
+		{
+			"name": "Random3",
+			"from": [6, 0, 11],
+			"to": [8, 2, 13],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [8, 8, 8]},
+			"faces": {
+				"north": {"uv": [0, 0, 2, 2], "texture": "#2"},
+				"east": {"uv": [0, 0, 2, 2], "texture": "#2"},
+				"south": {"uv": [0, 0, 2, 2], "texture": "#2"},
+				"west": {"uv": [0, 0, 2, 2], "texture": "#2"},
+				"up": {"uv": [0, 0, 2, 2], "texture": "#2"},
+				"down": {"uv": [0, 0, 2, 2], "texture": "#2"}
+			}
+		},
+		{
+			"name": "Random4",
+			"from": [13, 0, 10],
+			"to": [14, 1, 13],
+			"rotation": {"angle": 22.5, "axis": "x", "origin": [8, 8, 8]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#3"},
+				"east": {"uv": [0, 0, 3, 1], "texture": "#3"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#3"},
+				"west": {"uv": [0, 0, 2, 3], "texture": "#3"},
+				"up": {"uv": [0, -1, 1, 2], "texture": "#3"},
+				"down": {"uv": [0, 0, 1, 3], "texture": "#3"}
+			}
+		}
+	]
 }

--- a/src/main/resources/assets/projectvibrantjourneys/models/block/twigs0.json
+++ b/src/main/resources/assets/projectvibrantjourneys/models/block/twigs0.json
@@ -1,107 +1,108 @@
 {
+	"credit": "Made with Blockbench",
 	"parent": "block/thin_block",
-    "textures": {
-        "particle": "block/oak_log",
-        "0": "block/oak_log",
-        "1": "block/oak_leaves"
-    },
-    "elements": [
-        {
-            "name": "twig10",
-            "from": [ 3.0, 0.0, 8.0 ], 
-            "to": [ 16.0, 1.0, 9.0 ], 
-            "rotation": { "origin": [ 8.0, 8.0, 8.0 ], "axis": "y", "angle": 45.0 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 13.0, 1.0 ]},
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ]},
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 13.0, 1.0 ]},
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ]},
-                "up": { "texture": "#0", "uv": [ 1.0, 2.0, 14.0, 3.0 ]},
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 13.0, 1.0 ]}
-            }
-        },
-        {
-            "name": "Cube",
-            "from": [ 7.0, 0.0, 6.0 ], 
-            "to": [ 8.0, 1.0, 7.0 ], 
-            "rotation": { "origin": [ 8.0, 8.0, 8.0 ], "axis": "y", "angle": 45.0 },
-            "faces": {
-                "north": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ] , "tintindex": 0},
-                "east": { "texture": "#1", "uv": [ 0.0, 1.0, 1.0, 2.0 ] , "tintindex": 0},
-                "south": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ] , "tintindex": 0},
-                "west": { "texture": "#1", "uv": [ 0.0, 1.0, 1.0, 2.0 ] , "tintindex": 0},
-                "up": { "texture": "#1", "uv": [ 0.0, 1.0, 1.0, 2.0 ] , "tintindex": 0},
-                "down": { "texture": "#1", "uv": [ 0.0, 1.0, 1.0, 2.0 ] , "tintindex": 0}
-            }
-        },
-        {
-            "name": "Cube",
-            "from": [ 9.0, 0.0, 6.0 ], 
-            "to": [ 10.0, 1.0, 7.0 ], 
-            "rotation": { "origin": [ 8.0, 8.0, 8.0 ], "axis": "y", "angle": 45.0 },
-            "faces": {
-                "north": { "texture": "#1", "uv": [ 0.0, 1.0, 1.0, 2.0 ] , "tintindex": 0},
-                "east": { "texture": "#1", "uv": [ 5.0, 4.0, 6.0, 5.0 ], "tintindex": 0 },
-                "south": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ] , "tintindex": 0},
-                "west": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ] , "tintindex": 0},
-                "up": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ] , "tintindex": 0},
-                "down": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ] , "tintindex": 0}
-            }
-        },
-        {
-            "name": "Cube",
-            "from": [ 8.0, 0.0, 5.0 ], 
-            "to": [ 9.0, 1.0, 6.0 ], 
-            "rotation": { "origin": [ 8.0, 8.0, 8.0 ], "axis": "y", "angle": 45.0 },
-            "faces": {
-                "north": { "texture": "#1", "uv": [ 8.0, 0.0, 9.0, 1.0 ] , "tintindex": 0},
-                "east": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ] , "tintindex": 0},
-                "south": { "texture": "#1", "uv": [ 1.0, 3.0, 2.0, 4.0 ] , "tintindex": 0},
-                "west": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ] , "tintindex": 0},
-                "up": { "texture": "#1", "uv": [ 5.0, 5.0, 6.0, 6.0 ], "tintindex": 0 },
-                "down": { "texture": "#1", "uv": [ 0.0, 8.0, 1.0, 9.0 ], "tintindex": 0 }
-            }
-        },
-        {
-            "name": "Cube",
-            "from": [ 8.0, 1.0, 6.0 ], 
-            "to": [ 9.0, 2.0, 7.0 ], 
-            "rotation": { "origin": [ 8.0, 8.0, 8.0 ], "axis": "y", "angle": 45.0 },
-            "faces": {
-                "north": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ] , "tintindex": 0},
-                "east": { "texture": "#1", "uv": [ 2.0, 0.0, 3.0, 1.0 ] , "tintindex": 0},
-                "south": { "texture": "#1", "uv": [ 4.0, 0.0, 5.0, 1.0 ] , "tintindex": 0},
-                "west": { "texture": "#1", "uv": [ 0.0, 8.0, 1.0, 9.0 ], "tintindex": 0 },
-                "up": { "texture": "#1", "uv": [ 0.0, 1.0, 1.0, 2.0 ] , "tintindex": 0},
-                "down": { "texture": "#1", "uv": [ 3.0, 0.0, 4.0, 1.0 ] , "tintindex": 0}
-            }
-        },
-        {
-            "name": "Cube",
-            "from": [ 8.0, 0.0, 6.0 ], 
-            "to": [ 9.0, 1.0, 8.0 ], 
-            "rotation": { "origin": [ 8.0, 8.0, 8.0 ], "axis": "y", "angle": 45.0 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ]},
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ]},
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ]},
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 2.0, 1.0 ]},
-                "up": { "texture": "#0", "uv": [ 1.0, 2.0, 2.0, 4.0 ]},
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ]}
-            }
-        },
-        {
-            "name": "Cube",
-            "from": [ 11.0, 0.0, 5.0 ], 
-            "to": [ 14.0, 1.0, 6.0 ], 
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ]},
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ]},
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ]},
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ]},
-                "up": { "texture": "#0", "uv": [ 1.0, 2.0, 4.0, 3.0 ]},
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ]}
-            }
-        }
-    ]
+	"textures": {
+		"0": "block/oak_log",
+		"1": "block/oak_leaves",
+		"particle": "block/oak_log"
+	},
+	"elements": [
+		{
+			"name": "twig10",
+			"from": [3, 0, 8],
+			"to": [16, 1, 9],
+			"rotation": {"angle": 45, "axis": "y", "origin": [8, 8, 8]},
+			"faces": {
+				"north": {"uv": [0, 0, 13, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 13, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [1, 2, 14, 3], "texture": "#0"},
+				"down": {"uv": [0, 0, 13, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Cube",
+			"from": [7, 0, 6],
+			"to": [8, 1, 7],
+			"rotation": {"angle": 45, "axis": "y", "origin": [8, 8, 8]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#1", "tintindex": 0},
+				"east": {"uv": [0, 1, 1, 2], "texture": "#1", "tintindex": 0},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#1", "tintindex": 0},
+				"west": {"uv": [0, 1, 1, 2], "texture": "#1", "tintindex": 0},
+				"up": {"uv": [0, 1, 1, 2], "texture": "#1", "tintindex": 0},
+				"down": {"uv": [0, 1, 1, 2], "texture": "#1", "tintindex": 0}
+			}
+		},
+		{
+			"name": "Cube",
+			"from": [9, 0, 6],
+			"to": [10, 1, 7],
+			"rotation": {"angle": 45, "axis": "y", "origin": [8, 8, 8]},
+			"faces": {
+				"north": {"uv": [0, 1, 1, 2], "texture": "#1", "tintindex": 0},
+				"east": {"uv": [5, 4, 6, 5], "texture": "#1", "tintindex": 0},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#1", "tintindex": 0},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#1", "tintindex": 0},
+				"up": {"uv": [0, 0, 1, 1], "texture": "#1", "tintindex": 0},
+				"down": {"uv": [0, 0, 1, 1], "texture": "#1", "tintindex": 0}
+			}
+		},
+		{
+			"name": "Cube",
+			"from": [8, 0, 5],
+			"to": [9, 1, 6],
+			"rotation": {"angle": 45, "axis": "y", "origin": [8, 8, 8]},
+			"faces": {
+				"north": {"uv": [8, 0, 9, 1], "texture": "#1", "tintindex": 0},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#1", "tintindex": 0},
+				"south": {"uv": [1, 3, 2, 4], "texture": "#1", "tintindex": 0},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#1", "tintindex": 0},
+				"up": {"uv": [5, 5, 6, 6], "texture": "#1", "tintindex": 0},
+				"down": {"uv": [0, 8, 1, 9], "texture": "#1", "tintindex": 0}
+			}
+		},
+		{
+			"name": "Cube",
+			"from": [8, 1, 6],
+			"to": [9, 2, 7],
+			"rotation": {"angle": 45, "axis": "y", "origin": [8, 8, 8]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#1", "tintindex": 0},
+				"east": {"uv": [2, 0, 3, 1], "texture": "#1", "tintindex": 0},
+				"south": {"uv": [4, 0, 5, 1], "texture": "#1", "tintindex": 0},
+				"west": {"uv": [0, 8, 1, 9], "texture": "#1", "tintindex": 0},
+				"up": {"uv": [0, 1, 1, 2], "texture": "#1", "tintindex": 0},
+				"down": {"uv": [3, 0, 4, 1], "texture": "#1", "tintindex": 0}
+			}
+		},
+		{
+			"name": "Cube",
+			"from": [8, 0, 6],
+			"to": [9, 1, 8],
+			"rotation": {"angle": 45, "axis": "y", "origin": [8, 8, 8]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"up": {"uv": [1, 2, 2, 4], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "Cube",
+			"from": [11, 0, 5],
+			"to": [14, 0.9, 6],
+			"faces": {
+				"north": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [1, 2, 4, 3], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 1], "texture": "#0"}
+			}
+		}
+	]
 }

--- a/src/main/resources/assets/projectvibrantjourneys/models/block/twigs3.json
+++ b/src/main/resources/assets/projectvibrantjourneys/models/block/twigs3.json
@@ -1,134 +1,135 @@
 {
+	"credit": "Made with Blockbench",
 	"parent": "block/thin_block",
-    "textures": {
-        "particle": "block/oak_log",
-        "0": "block/oak_log",
-        "1": "block/oak_leaves"
-    },
-    "elements": [
-        {
-            "name": "twig1",
-            "from": [ -1.0, 2.0, 8.0 ], 
-            "to": [ 7.0, 3.0, 9.0 ], 
-            "rotation": { "origin": [ 8.0, 8.0, 8.0 ], "axis": "z", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 8.0, 1.0 ]},
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ]},
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 8.0, 1.0 ]},
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ]},
-                "up": { "texture": "#0", "uv": [ 1.0, 2.0, 9.0, 3.0 ]},
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 8.0, 1.0 ]}
-            }
-        },
-        {
-            "name": "leaf1",
-            "from": [ 11.0, 0.0, 4.0 ], 
-            "to": [ 12.0, 1.0, 5.0 ], 
-            "rotation": { "origin": [ 8.0, 8.0, 8.0 ], "axis": "y", "angle": 45.0 },
-            "faces": {
-                "north": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ], "tintindex": 0 },
-                "east": { "texture": "#1", "uv": [ 0.0, 1.0, 1.0, 2.0 ], "tintindex": 0 },
-                "south": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ], "tintindex": 0 },
-                "west": { "texture": "#1", "uv": [ 0.0, 1.0, 1.0, 2.0 ], "tintindex": 0 },
-                "up": { "texture": "#1", "uv": [ 0.0, 1.0, 1.0, 2.0 ], "tintindex": 0 },
-                "down": { "texture": "#1", "uv": [ 0.0, 1.0, 1.0, 2.0 ], "tintindex": 0 }
-            }
-        },
-        {
-            "name": "leaf2",
-            "from": [ 6.0, 0.0, 7.0 ], 
-            "to": [ 7.0, 1.0, 8.0 ], 
-            "rotation": { "origin": [ 8.0, 8.0, 8.0 ], "axis": "y", "angle": -22.5 },
-            "faces": {
-                "north": { "texture": "#1", "uv": [ 0.0, 1.0, 1.0, 2.0 ], "tintindex": 0 },
-                "east": { "texture": "#1", "uv": [ 5.0, 4.0, 6.0, 5.0 ], "tintindex": 0 },
-                "south": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ], "tintindex": 0 },
-                "west": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ], "tintindex": 0 },
-                "up": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ], "tintindex": 0 },
-                "down": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ], "tintindex": 0 }
-            }
-        },
-        {
-            "name": "leaf3",
-            "from": [ 1.0, 2.0, 9.0 ], 
-            "to": [ 2.0, 3.0, 10.0 ], 
-            "rotation": { "origin": [ 8.0, 8.0, 8.0 ], "axis": "z", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#1", "uv": [ 8.0, 0.0, 9.0, 1.0 ], "tintindex": 0 },
-                "east": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ], "tintindex": 0 },
-                "south": { "texture": "#1", "uv": [ 1.0, 3.0, 2.0, 4.0 ], "tintindex": 0 },
-                "west": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ], "tintindex": 0 },
-                "up": { "texture": "#1", "uv": [ 5.0, 5.0, 6.0, 6.0 ], "tintindex": 0 },
-                "down": { "texture": "#1", "uv": [ 0.0, 8.0, 1.0, 9.0 ], "tintindex": 0 }
-            }
-        },
-        {
-            "name": "leaf4",
-            "from": [ 7.0, 0.0, 12.0 ], 
-            "to": [ 8.0, 1.0, 13.0 ], 
-            "faces": {
-                "north": { "texture": "#1", "uv": [ 0.0, 0.0, 1.0, 1.0 ], "tintindex": 0 },
-                "east": { "texture": "#1", "uv": [ 2.0, 0.0, 3.0, 1.0 ], "tintindex": 0 },
-                "south": { "texture": "#1", "uv": [ 4.0, 0.0, 5.0, 1.0 ], "tintindex": 0 },
-                "west": { "texture": "#1", "uv": [ 0.0, 8.0, 1.0, 9.0 ], "tintindex": 0 },
-                "up": { "texture": "#1", "uv": [ 0.0, 1.0, 1.0, 2.0 ], "tintindex": 0 },
-                "down": { "texture": "#1", "uv": [ 3.0, 0.0, 4.0, 1.0 ], "tintindex": 0 }
-            }
-        },
-        {
-            "name": "twig2",
-            "from": [ 6.0, 0.0, 11.0 ], 
-            "to": [ 7.0, 1.0, 15.0 ], 
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ]},
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ]},
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ]},
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ]},
-                "up": { "texture": "#0", "uv": [ 1.0, 2.0, 2.0, 6.0 ]},
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ]}
-            }
-        },
-        {
-            "name": "twig3",
-            "from": [ 11.0, 0.0, 8.0 ], 
-            "to": [ 14.0, 1.0, 9.0 ], 
-            "rotation": { "origin": [ 8.0, 8.0, 8.0 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ]},
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ]},
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ] },
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ]},
-                "up": { "texture": "#0", "uv": [ 1.0, 2.0, 4.0, 3.0 ]},
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ]}
-            }
-        },
-        {
-            "name": "twig4",
-            "from": [ 7.0, 0.0, 6.0 ], 
-            "to": [ 8.0, 1.0, 9.0 ], 
-            "rotation": { "origin": [ 8.0, 8.0, 8.0 ], "axis": "y", "angle": -22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ]},
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ]},
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ]},
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ]},
-                "up": { "texture": "#0", "uv": [ 1.0, 2.0, 2.0, 5.0 ]},
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ]}
-            }
-        },
-        {
-            "name": "twig5",
-            "from": [ 4.0, 0.0, 6.0 ], 
-            "to": [ 12.0, 1.0, 7.0 ], 
-            "rotation": { "origin": [ 9.0, 8.0, 8.0 ], "axis": "y", "angle": -45.0 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 8.0, 1.0 ]},
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ]},
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 8.0, 1.0 ]},
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ]},
-                "up": { "texture": "#0", "uv": [ 1.0, 2.0, 9.0, 3.0 ]},
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 8.0, 1.0 ]}
-            }
-        }
-    ]
+	"textures": {
+		"0": "block/oak_log",
+		"1": "block/oak_leaves",
+		"particle": "block/oak_log"
+	},
+	"elements": [
+		{
+			"name": "twig1",
+			"from": [-1, 2, 8],
+			"to": [7, 3, 9],
+			"rotation": {"angle": 22.5, "axis": "z", "origin": [8, 8, 8]},
+			"faces": {
+				"north": {"uv": [0, 0, 8, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 8, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [1, 2, 9, 3], "texture": "#0"},
+				"down": {"uv": [0, 0, 8, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "leaf1",
+			"from": [11, 0, 4],
+			"to": [12, 1, 5],
+			"rotation": {"angle": 45, "axis": "y", "origin": [8, 8, 8]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#1", "tintindex": 0},
+				"east": {"uv": [0, 1, 1, 2], "texture": "#1", "tintindex": 0},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#1", "tintindex": 0},
+				"west": {"uv": [0, 1, 1, 2], "texture": "#1", "tintindex": 0},
+				"up": {"uv": [0, 1, 1, 2], "texture": "#1", "tintindex": 0},
+				"down": {"uv": [0, 1, 1, 2], "texture": "#1", "tintindex": 0}
+			}
+		},
+		{
+			"name": "leaf2",
+			"from": [6, 0, 7],
+			"to": [7, 1, 8],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [8, 8, 8]},
+			"faces": {
+				"north": {"uv": [0, 1, 1, 2], "texture": "#1", "tintindex": 0},
+				"east": {"uv": [5, 4, 6, 5], "texture": "#1", "tintindex": 0},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#1", "tintindex": 0},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#1", "tintindex": 0},
+				"up": {"uv": [0, 0, 1, 1], "texture": "#1", "tintindex": 0},
+				"down": {"uv": [0, 0, 1, 1], "texture": "#1", "tintindex": 0}
+			}
+		},
+		{
+			"name": "leaf3",
+			"from": [1, 2, 9],
+			"to": [2, 3, 10],
+			"rotation": {"angle": 22.5, "axis": "z", "origin": [8, 8, 8]},
+			"faces": {
+				"north": {"uv": [8, 0, 9, 1], "texture": "#1", "tintindex": 0},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#1", "tintindex": 0},
+				"south": {"uv": [1, 3, 2, 4], "texture": "#1", "tintindex": 0},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#1", "tintindex": 0},
+				"up": {"uv": [5, 5, 6, 6], "texture": "#1", "tintindex": 0},
+				"down": {"uv": [0, 8, 1, 9], "texture": "#1", "tintindex": 0}
+			}
+		},
+		{
+			"name": "leaf4",
+			"from": [7, 0, 12],
+			"to": [8, 1, 13],
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#1", "tintindex": 0},
+				"east": {"uv": [2, 0, 3, 1], "texture": "#1", "tintindex": 0},
+				"south": {"uv": [4, 0, 5, 1], "texture": "#1", "tintindex": 0},
+				"west": {"uv": [0, 8, 1, 9], "texture": "#1", "tintindex": 0},
+				"up": {"uv": [0, 1, 1, 2], "texture": "#1", "tintindex": 0},
+				"down": {"uv": [3, 0, 4, 1], "texture": "#1", "tintindex": 0}
+			}
+		},
+		{
+			"name": "twig2",
+			"from": [6, 0, 11],
+			"to": [7, 1, 15],
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"up": {"uv": [1, 2, 2, 6], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "twig3",
+			"from": [11, 0, 8],
+			"to": [14, 0.9, 9],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [8, 8, 8]},
+			"faces": {
+				"north": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [1, 2, 4, 3], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "twig4",
+			"from": [7, 0, 6],
+			"to": [8, 0.9, 9],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [8, 8, 8]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"up": {"uv": [1, 2, 2, 5], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "twig5",
+			"from": [4, 0, 6],
+			"to": [12, 1, 7],
+			"rotation": {"angle": -45, "axis": "y", "origin": [9, 8, 8]},
+			"faces": {
+				"north": {"uv": [0, 0, 8, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 8, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [1, 2, 9, 3], "texture": "#0"},
+				"down": {"uv": [0, 0, 8, 1], "texture": "#0"}
+			}
+		}
+	]
 }

--- a/src/main/resources/assets/projectvibrantjourneys/models/block/twigs4.json
+++ b/src/main/resources/assets/projectvibrantjourneys/models/block/twigs4.json
@@ -1,52 +1,52 @@
 {
+	"credit": "Made with Blockbench",
 	"parent": "block/thin_block",
-    "textures": {
-        "particle": "block/oak_log",
-        "0": "block/oak_log",
-        "1": "block/oak_leaves"
-    },
-    "elements": [
-        {
-            "name": "twig1",
-            "from": [ 11.0, 0.0, 6.0 ], 
-            "to": [ 12.0, 1.0, 10.0 ], 
-            "rotation": { "origin": [ 8.0, 8.0, 8.0 ], "axis": "y", "angle": -22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ]},
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ]},
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ]},
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 4.0, 1.0 ]},
-                "up": { "texture": "#0", "uv": [ 1.0, 2.0, 2.0, 6.0 ]},
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ]}
-            }
-        },
-        {
-            "name": "twig2",
-            "from": [ 10.0, 0.0, 11.0 ], 
-            "to": [ 13.0, 1.0, 12.0 ], 
-            "rotation": { "origin": [ 8.0, 8.0, 8.0 ], "axis": "y", "angle": -22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ]},
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ]},
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 3.0, 1.0 ]},
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ]},
-                "up": { "texture": "#0", "uv": [ 1.0, 2.0, 4.0, 3.0 ]},
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ]}
-            }
-        },
-        {
-            "name": "twig3",
-            "from": [ 4.0, 0.0, 11.0 ], 
-            "to": [ 13.0, 1.0, 12.0 ], 
-            "rotation": { "origin": [ 9.0, 8.0, 8.0 ], "axis": "y", "angle": 22.5 },
-            "faces": {
-                "north": { "texture": "#0", "uv": [ 0.0, 0.0, 9.0, 1.0 ]},
-                "east": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ]},
-                "south": { "texture": "#0", "uv": [ 0.0, 0.0, 9.0, 1.0 ]},
-                "west": { "texture": "#0", "uv": [ 0.0, 0.0, 1.0, 1.0 ]},
-                "up": { "texture": "#0", "uv": [ 1.0, 2.0, 10.0, 3.0 ]},
-                "down": { "texture": "#0", "uv": [ 0.0, 0.0, 9.0, 1.0 ]}
-            }
-        }
-    ]
+	"textures": {
+		"0": "block/oak_log",
+		"particle": "block/oak_log"
+	},
+	"elements": [
+		{
+			"name": "twig1",
+			"from": [11, 0, 6],
+			"to": [12, 0.9, 10],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [8, 8, 8]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 4, 1], "texture": "#0"},
+				"up": {"uv": [1, 2, 2, 6], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "twig2",
+			"from": [10, 0, 11],
+			"to": [13, 0.9, 12],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [8, 8, 8]},
+			"faces": {
+				"north": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 3, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [1, 2, 4, 3], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 1], "texture": "#0"}
+			}
+		},
+		{
+			"name": "twig3",
+			"from": [4, 0, 11],
+			"to": [13, 1, 12],
+			"rotation": {"angle": 22.5, "axis": "y", "origin": [9, 8, 8]},
+			"faces": {
+				"north": {"uv": [0, 0, 9, 1], "texture": "#0"},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {"uv": [0, 0, 9, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"up": {"uv": [1, 2, 10, 3], "texture": "#0"},
+				"down": {"uv": [0, 0, 9, 1], "texture": "#0"}
+			}
+		}
+	]
 }


### PR DESCRIPTION
Some models have flickering textures, caused by cuboids overlapping each other:

[Screencast from 2022-12-04 14-08-22.webm](https://user-images.githubusercontent.com/42828197/205492394-3fb49fa2-6957-4455-9778-1a86583f03b8.webm)

This PR fixes that by minimally adjusting the height of individual cuboids:

[Screencast from 2022-12-04 14-09-21.webm](https://user-images.githubusercontent.com/42828197/205492432-aa7591ef-c5d0-4c76-b1e1-ec3ba53bf8da.webm)
