### PR TITLE
Fix icicle & slime nodule transparency render type

### DIFF
--- a/src/main/resources/assets/projectvibrantjourneys/models/block/icicle_down_base.json
+++ b/src/main/resources/assets/projectvibrantjourneys/models/block/icicle_down_base.json
@@ -1,6 +1,6 @@
 {
   "parent": "minecraft:block/pointed_dripstone",
-  "render_type": "minecraft:translucent",
+  "render_type": "minecraft:tripwire",
   "textures": {
     "cross": "projectvibrantjourneys:block/icicle_down_base"
   }

--- a/src/main/resources/assets/projectvibrantjourneys/models/block/icicle_down_frustum.json
+++ b/src/main/resources/assets/projectvibrantjourneys/models/block/icicle_down_frustum.json
@@ -1,6 +1,6 @@
 {
   "parent": "minecraft:block/pointed_dripstone",
-  "render_type": "minecraft:translucent",
+  "render_type": "minecraft:tripwire",
   "textures": {
     "cross": "projectvibrantjourneys:block/icicle_down_frustum"
   }

--- a/src/main/resources/assets/projectvibrantjourneys/models/block/icicle_down_middle.json
+++ b/src/main/resources/assets/projectvibrantjourneys/models/block/icicle_down_middle.json
@@ -1,6 +1,6 @@
 {
   "parent": "minecraft:block/pointed_dripstone",
-  "render_type": "minecraft:translucent",
+  "render_type": "minecraft:tripwire",
   "textures": {
     "cross": "projectvibrantjourneys:block/icicle_down_middle"
   }

--- a/src/main/resources/assets/projectvibrantjourneys/models/block/icicle_down_tip.json
+++ b/src/main/resources/assets/projectvibrantjourneys/models/block/icicle_down_tip.json
@@ -1,6 +1,6 @@
 {
   "parent": "minecraft:block/pointed_dripstone",
-  "render_type": "minecraft:translucent",
+  "render_type": "minecraft:tripwire",
   "textures": {
     "cross": "projectvibrantjourneys:block/icicle_down_tip"
   }

--- a/src/main/resources/assets/projectvibrantjourneys/models/block/icicle_down_tip_merge.json
+++ b/src/main/resources/assets/projectvibrantjourneys/models/block/icicle_down_tip_merge.json
@@ -1,6 +1,6 @@
 {
   "parent": "minecraft:block/pointed_dripstone",
-  "render_type": "minecraft:translucent",
+  "render_type": "minecraft:tripwire",
   "textures": {
     "cross": "projectvibrantjourneys:block/icicle_down_tip_merge"
   }

--- a/src/main/resources/assets/projectvibrantjourneys/models/block/icicle_up_base.json
+++ b/src/main/resources/assets/projectvibrantjourneys/models/block/icicle_up_base.json
@@ -1,6 +1,6 @@
 {
   "parent": "minecraft:block/pointed_dripstone",
-  "render_type": "minecraft:translucent",
+  "render_type": "minecraft:tripwire",
   "textures": {
     "cross": "projectvibrantjourneys:block/icicle_up_base"
   }

--- a/src/main/resources/assets/projectvibrantjourneys/models/block/icicle_up_frustum.json
+++ b/src/main/resources/assets/projectvibrantjourneys/models/block/icicle_up_frustum.json
@@ -1,6 +1,6 @@
 {
   "parent": "minecraft:block/pointed_dripstone",
-  "render_type": "minecraft:translucent",
+  "render_type": "minecraft:tripwire",
   "textures": {
     "cross": "projectvibrantjourneys:block/icicle_up_frustum"
   }

--- a/src/main/resources/assets/projectvibrantjourneys/models/block/icicle_up_middle.json
+++ b/src/main/resources/assets/projectvibrantjourneys/models/block/icicle_up_middle.json
@@ -1,6 +1,6 @@
 {
   "parent": "minecraft:block/pointed_dripstone",
-  "render_type": "minecraft:translucent",
+  "render_type": "minecraft:tripwire",
   "textures": {
     "cross": "projectvibrantjourneys:block/icicle_up_middle"
   }

--- a/src/main/resources/assets/projectvibrantjourneys/models/block/icicle_up_tip.json
+++ b/src/main/resources/assets/projectvibrantjourneys/models/block/icicle_up_tip.json
@@ -1,6 +1,6 @@
 {
   "parent": "minecraft:block/pointed_dripstone",
-  "render_type": "minecraft:translucent",
+  "render_type": "minecraft:tripwire",
   "textures": {
     "cross": "projectvibrantjourneys:block/icicle_up_tip"
   }

--- a/src/main/resources/assets/projectvibrantjourneys/models/block/icicle_up_tip_merge.json
+++ b/src/main/resources/assets/projectvibrantjourneys/models/block/icicle_up_tip_merge.json
@@ -1,6 +1,6 @@
 {
   "parent": "minecraft:block/pointed_dripstone",
-  "render_type": "minecraft:translucent",
+  "render_type": "minecraft:tripwire",
   "textures": {
     "cross": "projectvibrantjourneys:block/icicle_up_tip_merge"
   }

--- a/src/main/resources/assets/projectvibrantjourneys/models/block/slime_nodule.json
+++ b/src/main/resources/assets/projectvibrantjourneys/models/block/slime_nodule.json
@@ -1,5 +1,5 @@
 {
-	"render_type": "minecraft:translucent",
+	"render_type": "minecraft:tripwire",
 	"textures": {
 		"0": "minecraft:block/slime_block",
 		"particle": "minecraft:block/slime_block"


### PR DESCRIPTION
The `minecraft:tripwire` render type allows transparent faces behind other ones on the same model to render. This fixes the issue where icicles would 'clip' the faces behind them off if you looked at them sideways.