### PR TITLE
Add Support for Applied Energistics 2 Growth Accelerator

### DIFF
--- a/src/generated/resources/.cache/b6684432db63412033cff20525b2600ed061e916
+++ b/src/generated/resources/.cache/b6684432db63412033cff20525b2600ed061e916
@@ -1,4 +1,5 @@
-// 1.21.1	2024-08-12T00:29:42.2528479	Tags for minecraft:block mod id projectvibrantjourneys
+// 1.21.1	2025-04-03T01:50:40.8393875	Tags for minecraft:block mod id projectvibrantjourneys
+94211d3c4ce277cc4b33a5348e5df2c1b34b81ae data/ae2/tags/block/growth_acceleratable.json
 97a56113914dadaab1bdcdf472144039f027a2ce data/c/tags/block/gravels.json
 c8616a47d8519a12c09ad1abf686961898be92f5 data/c/tags/block/sands.json
 c8616a47d8519a12c09ad1abf686961898be92f5 data/c/tags/block/sands/red.json

--- a/src/generated/resources/data/ae2/tags/block/growth_acceleratable.json
+++ b/src/generated/resources/data/ae2/tags/block/growth_acceleratable.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "projectvibrantjourneys:cindercane"
+  ]
+}

--- a/src/main/java/dev/orderedchaos/projectvibrantjourneys/data/tags/PVJBlockTagsProvider.java
+++ b/src/main/java/dev/orderedchaos/projectvibrantjourneys/data/tags/PVJBlockTagsProvider.java
@@ -3,6 +3,7 @@ package dev.orderedchaos.projectvibrantjourneys.data.tags;
 import dev.orderedchaos.projectvibrantjourneys.core.ProjectVibrantJourneys;
 import dev.orderedchaos.projectvibrantjourneys.core.registry.PVJBlocks;
 import dev.orderedchaos.projectvibrantjourneys.data.tags.PVJTags;
+import dev.orderedchaos.projectvibrantjourneys.integration.AppliedEnergistics2.AE2Tags;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.data.PackOutput;
 import net.minecraft.tags.BlockTags;
@@ -249,5 +250,7 @@ public class PVJBlockTagsProvider extends BlockTagsProvider {
       PVJBlocks.WHITE_WILDFLOWERS.get(),
       PVJBlocks.MIXED_WILDFLOWERS.get()
     );
+
+    this.tag(AE2Tags.GROWTH_ACCELERATABLE).add(PVJBlocks.CINDERCANE.get());
   }
 }

--- a/src/main/java/dev/orderedchaos/projectvibrantjourneys/integration/AppliedEnergistics2/AE2Tags.java
+++ b/src/main/java/dev/orderedchaos/projectvibrantjourneys/integration/AppliedEnergistics2/AE2Tags.java
@@ -1,0 +1,27 @@
+package dev.orderedchaos.projectvibrantjourneys.integration.AppliedEnergistics2;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.level.block.Block;
+
+/**
+ * Integration with Applied Energistics 2
+ * https://github.com/AppliedEnergistics/Applied-Energistics-2
+ * 
+ */
+
+public class AE2Tags {
+  /* BLOCKS */
+
+  /**
+   * Growth accelerators from Applied Energistics 2 will trigger additional random ticks for blocks in that tag, regardless of what the
+   * blocks are.
+  */
+  public static final TagKey<Block> GROWTH_ACCELERATABLE = createBlockTag("growth_acceleratable");
+
+private static TagKey<Block> createBlockTag(final String location) {
+    return BlockTags.create(ResourceLocation.fromNamespaceAndPath("ae2", location));
+  }
+
+}


### PR DESCRIPTION
As a player, I would like to be able to utilize the AE2 Growth Accelerator with cindercane to speed up the growth process.
This gives cindercane the tag that AE2 uses to determine which blocks to apply random ticks to.